### PR TITLE
Add .pylintrc and runtests.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,241 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add <file or directory> to the black list. It should be a base name, not a
+# path. You may set this option multiple times.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifier separated by comma (,) or put this option
+# multiple time.
+
+# I0011: reports local disable.
+# W0603: using 'global' statement, which is discouraged but sometimes necessary.
+# W0511: 'notes' comments like 'TODO' or 'FIXME'.
+# R0201: method could be a function. Humans can judge this.
+# R0903: method has too few methods. Humans can judge this.
+disable=I0011,W0603,W0511,R0201,R0903
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html
+output-format=colorized
+
+# Include message's id in output
+include-ids=yes
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (R0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (R0004).
+comment=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject,FakeValues,FakeVsysBackend,MockCfg
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1200
+
+# String used as indentation unit. Changed to 2 spaces from default of 4.
+indent-string='  '
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__)|[a-z_][a-z0-9_]*)$
+
+# Regular expression which should only match correct class names
+class-rgx=([A-Z_][a-zA-Z0-9]+|[A-Z_][a-zA-Z0-9_]+Tests)$
+
+# Regular expression which should only match correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct method names
+method-rgx=([a-z_][a-z0-9_]{2,30}|test[a-zA-Z0-9_]+|setUp|xtest.*)$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Regular expression which should only match functions or classes name which do
+# not require a docstring
+no-docstring-rgx=__.*__|main|init_.*|[x]*test.*|info|error|warning|.*Tests.*|Mock.*|fake.*
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching names used for dummy variables (i.e. not used).
+dummy-variables-rgx=_|dummy|unused_.*
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=6
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|self
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=8
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=30
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp

--- a/.pylintrc
+++ b/.pylintrc
@@ -122,7 +122,7 @@ class-rgx=([A-Z_][a-zA-Z0-9]+|[A-Z_][a-zA-Z0-9_]+Tests)$
 function-rgx=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression which should only match correct method names
-method-rgx=([a-z_][a-z0-9_]{2,30}|test[a-zA-Z0-9_]+|setUp|xtest.*)$
+method-rgx=([a-z_][a-z0-9_]{2,30}|test[a-zA-Z0-9_]+|setUp|tearDown|xtest.*)$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$

--- a/runtests
+++ b/runtests
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# runtests runs pylint and coverage checks on all *_test.py and tested modules.
+#
+# Normal operation is to execute runtests with no arguments. Optionally,
+# runtests accepts a single argument for the name of a test file.
+# 
+# Example:
+#   ./runtests config/mlab_test.py
+#
+# To report additional status information during the coverage report.
+#   DEBUG=1 ./runtests [test_file]
+#
+
+if test -z "$( type -p coverage )" ; then
+  echo "please install python-mock"
+  echo "please install python-coverage"
+  exit 1
+fi
+
+if test -z "$( type -p pylint )" ; then
+  echo "please install pylint"
+  exit 1
+fi
+
+# Only test the first command line argument (if present), otherwise test all
+# files that end with _test.py.
+TEST_FILES=${1:-$( find ./ -name "*_test.py" )}
+
+# If DEBUG is set, enable verbose coverage status ("-v") during the run.
+VERBOSE_COVERAGE=${DEBUG:+-v}
+
+# Exit on first execution error.
+set -e
+
+# Set coverage reports output path to base directory for combination later.
+export COVERAGE_FILE="$PWD/.coverage"
+HTMLDIR="$PWD/coverage-report"
+mkdir -p "${HTMLDIR}"
+
+# Erase old reports.
+coverage -e
+rm -f .coverage*
+
+for filename in ${TEST_FILES} ; do
+  # Run pylint on file and the test.
+  # A non-zero exit status will exit runtests.
+  echo "${filename}"
+  pylint ${filename/_test/}
+  pylint ${filename}
+  pushd $(dirname $filename) > /dev/null
+    # Run coverage on the test (which imports the file itself). 
+    basefile=$(basename $filename)
+    echo coverage -p -x ${basefile} ${VERBOSE_COVERAGE}
+    coverage -p -x ${basefile} ${VERBOSE_COVERAGE}
+  popd > /dev/null
+done
+
+# Combine all reports above.
+coverage -c
+
+# Generate HTML report, storing output to HTMLDIR.
+coverage -b -d "${HTMLDIR}"


### PR DESCRIPTION
This pull request adds two files. The first is a pylintrc, which helps enforce style rules with pylint. The second is runtests, which is a simple bash script that automates running pylint, unit tests, and test-coverage reports based on the unit tests.