### PR TITLE
Add config and cron scripts for mlab_export.py

### DIFF
--- a/export/export_metrics.conf
+++ b/export/export_metrics.conf
@@ -1,0 +1,114 @@
+[metrics]
+
+cpu_cores.gauge:                       cpu.cores
+cpu_total.cpu-idle:                    cpu.total.idle
+cpu_total.cpu-interrupt:               cpu.total.interrupt
+cpu_total.cpu-nice:                    cpu.total.nice
+cpu_total.cpu-softirq:                 cpu.total.softirq
+cpu_total.cpu-steal:                   cpu.total.steal
+cpu_total.cpu-system:                  cpu.total.system
+cpu_total.cpu-user:                    cpu.total.user
+cpu_total.cpu-wait:                    cpu.total.wait
+
+cpu_total.vs_cpu-system:               cpu.total.system
+cpu_total.vs_cpu-user:                 cpu.total.user
+
+storage.vs_io_bytes.read:              storage.io.bytes.read
+storage.vs_io_bytes.write:             storage.io.bytes.write
+storage.vs_io_ops.read:                storage.io.ops.read
+storage.vs_io_ops.write:               storage.io.ops.write
+storage.vs_io_time.read:               storage.io.time.read
+storage.vs_io_time.write:              storage.io.time.write
+
+df.df-root.used:                       disk.root.bytes.used
+df.df-root.free:                       disk.root.bytes.free
+df.df-vservers.used:                   disk.vservers.bytes.used
+df.df-vservers.free:                   disk.vservers.bytes.free
+
+df-root.df_inodes-free:                disk.root.inodes.free
+df-root.df_inodes-reserved:            disk.root.inodes.reserved
+df-root.df_inodes-used:                disk.root.inodes.used
+df-vservers.df_inodes-free:            disk.vservers.inodes.free
+df-vservers.df_inodes-reserved:        disk.vservers.inodes.reserved
+df-vservers.df_inodes-used:            disk.vservers.inodes.used
+
+disk-dm-0.disk_merged.read:            disk.swap.io.merged.read
+disk-dm-0.disk_merged.write:           disk.swap.io.merged.write
+disk-dm-0.disk_octets.read:            disk.swap.io.bytes.read
+disk-dm-0.disk_octets.write:           disk.swap.io.bytes.write
+disk-dm-0.disk_ops.read:               disk.swap.io.ops.read
+disk-dm-0.disk_ops.write:              disk.swap.io.ops.write
+disk-dm-0.disk_time.read:              disk.swap.io.time.read
+disk-dm-0.disk_time.write:             disk.swap.io.time.write
+
+disk-dm-1.disk_merged.read:            disk.root.io.merged.read
+disk-dm-1.disk_merged.write:           disk.root.io.merged.write
+disk-dm-1.disk_octets.read:            disk.root.io.bytes.read
+disk-dm-1.disk_octets.write:           disk.root.io.bytes.write
+disk-dm-1.disk_ops.read:               disk.root.io.ops.read
+disk-dm-1.disk_ops.write:              disk.root.io.ops.write
+disk-dm-1.disk_time.read:              disk.root.io.time.read
+disk-dm-1.disk_time.write:             disk.root.io.time.write
+
+disk-dm-2.disk_merged.read:            disk.vserver.io.merged.read
+disk-dm-2.disk_merged.write:           disk.vserver.io.merged.write
+disk-dm-2.disk_octets.read:            disk.vserver.io.bytes.read
+disk-dm-2.disk_octets.write:           disk.vserver.io.bytes.write
+disk-dm-2.disk_ops.read:               disk.vserver.io.ops.read
+disk-dm-2.disk_ops.write:              disk.vserver.io.ops.write
+disk-dm-2.disk_time.read:              disk.vserver.io.time.read
+disk-dm-2.disk_time.write:             disk.vserver.io.time.write
+
+interface.if_errors-eth0.rx:           interface.eth0.errors.rx
+interface.if_errors-eth0.tx:           interface.eth0.errors.tx
+interface.if_octets-eth0.rx:           interface.eth0.bytes.rx
+interface.if_octets-eth0.tx:           interface.eth0.bytes.tx
+interface.if_packets-eth0.rx:          interface.eth0.packets.rx
+interface.if_packets-eth0.tx:          interface.eth0.packets.tx
+
+memory.memory-buffered:                memory.buffered
+memory.memory-cached:                  memory.cached
+memory.memory-free:                    memory.free
+memory.memory-used:                    memory.used
+memory.vs_memory-anon:                 memory.anonymous
+memory.vs_memory-rss:                  memory.rss
+memory.vs_memory-vm:                   memory.vsize
+memory.vs_memory-vml:                  memory.vsize_locked
+
+network.if_octets-ipv4.rx:             network.ipv4.bytes.rx
+network.if_octets-ipv4.tx:             network.ipv4.bytes.tx
+network.if_octets-ipv6.rx:             network.ipv6.bytes.rx
+network.if_octets-ipv6.tx:             network.ipv6.bytes.tx
+network.vs_network_syscalls-ipv4.recv: network.ipv4.syscalls.recv
+network.vs_network_syscalls-ipv4.send: network.ipv4.syscalls.send
+network.vs_network_syscalls-ipv6.recv: network.ipv6.syscalls.recv
+network.vs_network_syscalls-ipv6.send: network.ipv6.syscalls.send
+
+processes.fork_rate:                   system.fork_rate
+
+storage.vs_quota_bytes-quota.free:     storage.quota.bytes.free
+storage.vs_quota_bytes-quota.used:     storage.quota.bytes.used
+swap.swap-cached:                      swap.cached
+swap.swap-free:                        swap.free
+swap.swap-used:                        swap.used
+swap.swap_io-in:                       swap.io.in
+swap.swap_io-out:                      swap.io.out
+
+context.vs_vlimit-files:                context.vlimit.files
+context.vs_vlimit-openfd:               context.vlimit.openfds
+context.vs_vlimit-sockets:              context.vlimit.sockets
+context.vs_vlimit-processes:            context.processes
+context.vs_uptime:                      context.uptime
+context.vs_threads_basic-other:         context.threads.other
+context.vs_threads_basic-running:       context.threads.running
+
+uptime.uptime:                         system.uptime
+vmem.vmpage_faults.majflt:             system.pages.major_faults
+vmem.vmpage_faults.minflt:             system.pages.minor_faults
+vmem.vmpage_io-memory.in:              system.pages.page_in
+vmem.vmpage_io-memory.out:             system.pages.page_out
+vmem.vmpage_io-swap.in:                system.pages.swap_in
+vmem.vmpage_io-swap.out:               system.pages.swap_out
+vmem.vmpage_number-free_pages:         system.pages.free
+vmem.vmpage_number-slab_reclaimable:   system.pages.slab_reclaimable
+vmem.vmpage_number-slab_unreclaimable: system.pages.slab_unreclaimable

--- a/export/mlab_export.cron
+++ b/export/mlab_export.cron
@@ -1,0 +1,6 @@
+#
+# Runs hourly to export the latest hour of collectd-mlab data to json.
+#
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+
+11 * * * * root	 /usr/bin/mlab_export.py --compress > /dev/null

--- a/export/mlab_export.cron
+++ b/export/mlab_export.cron
@@ -3,4 +3,28 @@
 #
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 
-11 * * * * root	 /usr/bin/mlab_export.py --compress > /dev/null
+# Why run mlab_export.py at 10 minutes after the hour?
+#
+# Basically, we just need to guarantee that values cached by collectd have been
+# written to disk.
+#
+# All the details: With default settings, mlab_export.py saves data aligned on
+# the hour, e.g. 09:00 to 10:00. However, M-Lab's collectd configuration uses
+# the CacheTimeout option to batch disk writes to RRDs.
+# /etc/collectd-mlab.conf sets CacheTimeout to 300 seconds. Collectd guarantees
+# that it will *being* writting cached values after CacheTimeout but does not
+# guarantee *when the write completes*.
+#
+# So, to guarantee that all collectd data is available on disk when
+# mlab_export.py runs, the cron start time should be:
+#
+#   "--ts_end" + "CacheTimeout" + "safety factor"
+#
+# The mlab_export.py script enforces a safety factor of 5 minutes through the
+# --ts_offset flag. The --ts_offset option equals:
+#
+#   "CacheTimeout + safety factor" = 10 minutes.
+#
+# Thus, the cron start matches --ts_offset.
+#
+10 * * * * root	 /usr/bin/mlab_export.py --compress > /dev/null

--- a/export/mlab_export_cleanup.cron
+++ b/export/mlab_export_cleanup.cron
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# mlab_export runs hourly and exports metric data to /var/spool/mlab_utility.
+#
+# mlab_export_cleanup runs daily to remove files in /var/spool/mlab_utility
+# older than 30 days.
+
+# Rotate log over last week.
+LOG=$(( $(date +%j) % 7 ))
+LOGFILE=/var/log/mlab-export-cleanup.log.${LOG}
+RSYNCDIR=/var/spool/mlab_utility/resource-utilization
+
+# Find all files with mtime older than 30 days (+29), print, and remove file.
+find "${RSYNCDIR}" -type f -mtime +29 -a -print -delete &> $LOGFILE
+
+# Find all empty directories, and remove the directory.
+find "${RSYNCDIR}" -type d -empty -delete &> /dev/null


### PR DESCRIPTION
This change adds two cron scripts for automating mlab_export.py and a
config file that defines how metrics are named and which metrics are exported.