### PR TITLE
Fix mlab_test.py improper usage of assert_called_once.

### DIFF
--- a/plugin/mlab_test.py
+++ b/plugin/mlab_test.py
@@ -482,7 +482,7 @@ class MlabCollectdPlugin_CoverageTests(unittest.TestCase):
     # should be updated.
     mlab.plugin_shutdown()
 
-    mock_info.assert_called_once()
+    self.assertTrue(mock_info.called)
 
   @mock.patch('mlab.os.getpid')
   def testcover_plugin_initialize(self, mock_getpid):
@@ -499,7 +499,7 @@ class MlabCollectdPlugin_CoverageTests(unittest.TestCase):
     # Wrong value types are logged and ignored.
     mlab.submit_generic('fake.host', 'plugin', 'type', 'wrong value type')
 
-    mock_error.assert_called_once()
+    self.assertTrue(mock_error.called)
 
 
 class MlabCollectdPlugin_UnitTests(unittest.TestCase):


### PR DESCRIPTION
This change corrects usage of assert_called_once to an assertion that
the mock was called at all. The method assert_called_once does not
actually exist. And, default mocks allow this behavior without error.

A future change should consider using one of the 'spec', or 'spec_set'
features on all mocks to enforce strict presence for any used
attributes.