### PR TITLE
Add mlab-view for limited support for collectd-web CGI scripts

### DIFF
--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -68,7 +68,6 @@ install -D -m 644 export/export_metrics.conf		%{buildroot}/usr/share/collectd-ml
 
 # Configuration for *limited* access to collectd-web.
 install -D -m 755 viewer/mlab-view 			%{buildroot}/usr/bin/mlab-view
-install -D -m 755 viewer/httpd-config.py		%{buildroot}/usr/share/collectd-mlab/httpd-config.py
 install -D -m 644 viewer/httpd.collectd.conf		%{buildroot}/usr/share/collectd-mlab/httpd.conf
 install -D -m 644 viewer/collection-mlab.conf		%{buildroot}/etc/collection-mlab.conf
 
@@ -103,9 +102,8 @@ rm -rf $RPM_BUILD_ROOT
 /etc/cron.d/mlab_export.cron
 /etc/cron.daily/mlab_export_cleanup.cron
 
-# Configuration and *limited* access to collectd-web.
+# Configuration for *limited* access to collectd-web.
 /usr/bin/mlab-view
-/usr/share/collectd-mlab/httpd-config.py
 /usr/share/collectd-mlab/httpd.conf
 /etc/collection-mlab.conf
 
@@ -123,15 +121,6 @@ rm -rf $RPM_BUILD_ROOT
 COLLECTD_LINK="/usr/share/collectd/collection3/etc/collection.conf"
 if test -f "${COLLECTD_LINK}" ; then
   ln -f -s /etc/collection-mlab.conf "${COLLECTD_LINK}"
-fi
-
-# TODO: how to disable apache inside the slice?
-# TODO: what other options are available for serving the cgi files?
-# TODO: should the access control script be run by mlab-view instead?
-# NOTE: generate an apache access rule based on local IP address.
-ACCESS_CONF="/usr/share/collectd-mlab/access.conf"
-if ! test -f "${ACCESS_CONF}" ; then
-  /usr/share/collectd-mlab/httpd-config.py > "${ACCESS_CONF}"
 fi
 
 chkconfig crond on

--- a/viewer/collection-mlab.conf
+++ b/viewer/collection-mlab.conf
@@ -1,0 +1,871 @@
+DataDir "/var/lib/collectd/rrd/"
+GraphWidth 400
+#UnixSockAddr "/var/run/collectd-unixsock"
+<Type apache_bytes>
+  DataSources count
+  DSName "count Bytes/s"
+  RRDTitle "Apache Traffic"
+  RRDVerticalLabel "Bytes/s"
+  RRDFormat "%5.1lf%s"
+  Color count 0000ff
+</Type>
+<Type apache_requests>
+  DataSources count
+  DSName "count Requests/s"
+  RRDTitle "Apache Traffic"
+  RRDVerticalLabel "Requests/s"
+  RRDFormat "%5.2lf"
+  Color count 00d000
+</Type>
+<Type apache_scoreboard>
+  Module GenericStacked
+  DataSources count
+  RRDTitle "Apache scoreboard on {hostname}"
+  RRDVerticalLabel "Slots"
+  RRDFormat "%6.2lf"
+  DSName closing Closing
+  DSName dnslookup DNS lookup
+  DSName finishing Finishing
+  DSName idle_cleanup Idle cleanup
+  DSName keepalive Keep alive
+  DSName logging Logging
+  DSName open Open (empty)
+  DSName reading Reading
+  DSName sending Sending
+  DSName starting Starting
+  DSName waiting Waiting
+  Order open closing dnslookup finishing idle_cleanup keepalive logging open reading sending starting waiting
+  Color closing      000080
+  Color dnslookup    ff0000
+  Color finishing    008080
+  Color idle_cleanup ffff00
+  Color keepalive    0080ff
+  Color logging      a000a0
+  Color open         e0e0e0
+  Color reading      0000ff
+  Color sending      00e000
+  Color starting     ff00ff
+  Color waiting      ffb000
+</Type>
+<Type arc_counts>
+  Module ArcCounts
+  RRDTitle "ARC {type_instance} on {hostname}"
+# RRDOptions ...
+</Type>
+<Type arc_l2_bytes>
+  Module GenericIO
+  DataSources read write
+  DSName  "read Read   "
+  DSName "write Written"
+  RRDTitle "L2ARC traffic"
+  RRDVerticalLabel "Bytes per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type arc_l2_size>
+  RRDTitle "L2ARC size on {hostname}"
+  RRDVerticalLabel "Size"
+  RRDFormat "%4.0lf%s"
+  RRDOptions -b 1024
+  DSName "value Current size"
+  Color value  00e000
+</Type>
+<Type arc_size>
+  DataSources "current target minlimit maxlimit"
+  RRDTitle "ARC size on {hostname}"
+  RRDVerticalLabel "Size"
+  RRDFormat "%4.0lf%s"
+  RRDOptions -b 1024
+  DSName  "current Current size"
+  DSName   "target Target size "
+  DSName "maxlimit Max size    "
+  DSName "minlimit Min size    "
+  Color current  00e000
+  Color target   0000ff
+  Color minlimit ff0000
+  Color maxlimit ff00ff
+</Type>
+<Type arc_ratio>
+  DataSources value
+  RRDTitle "{type_instance}ARC ratio on {hostname}"
+  RRDVerticalLabel "Ratio"
+  RRDFormat "%4.1lf"
+  RRDOptions -l 0
+  DSName "value Hit ratio"
+</Type>
+<Type cache_ratio>
+  DataSources value
+  DSName value Percent
+  RRDTitle "Cache hit ratio for {plugin_instance} {type_instance}"
+  RRDVerticalLabel "Percent"
+  RRDFormat "%5.1lf %%"
+</Type>
+<Type cpu>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "CPU {plugin_instance} usage"
+  RRDVerticalLabel "Jiffies"
+  RRDFormat "%5.2lf"
+  RRDOptions -h 512 -w 512 -b 1024 -l 0
+  DSName idle Idle
+  DSName nice Nice
+  DSName user User
+  DSName wait Wait-IO
+  DSName system System
+  DSName softirq SoftIRQ
+  DSName interrupt IRQ
+  DSName steal Steal
+  Order idle nice user wait system softirq interrupt steal
+  Color idle      e8e8e8
+  Color nice      00e000
+  Color user      0000ff
+  Color wait      ffb000
+  Color system    ff0000
+  Color softirq   ff00ff
+  Color interrupt a000a0
+  Color steal     000000
+</Type>
+<Type current>
+  DataSources value
+  DSName value Current
+  RRDTitle "Current ({type_instance})"
+  RRDVerticalLabel "Ampere"
+  RRDFormat "%4.1lfA"
+  Color value ffb000
+</Type>
+<Type df>
+  Module Df
+  DataSources free used
+</Type>
+<Type df_complex>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "disk usage on {plugin_instance}"
+  RRDVerticalLabel "Byte"
+  RRDFormat "%6.2lf%s"
+  DSName "snap_used    used for snapshots"
+  DSName "snap_reserved snapshot reserve "
+  DSName "used         in use            "
+  DSName "free         free              "
+  DSName "sis_saved    sis_saved         "
+  Order free snap_used snap_reserved sis_saved used
+  Color snap_reverse   ff8000
+  Color used  ff0000
+  Color snap_used   000080
+  Color snap_reserved   ff8000
+  Color free  00ff00
+  Color sis_saved 00e0e0
+</Type>
+<Type df_inodes>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "disk inode usage on {plugin_instance}"
+  RRDVerticalLabel "Inodes"
+  RRDFormat "%6.2lf%s"
+  DSName "reserved Reserved "
+  DSName "used     In use   "
+  DSName "free     Free     "
+  Order free used reserved
+  Color used  ff0000
+  Color reserved   ff8000
+  Color free  00ff00
+</Type>
+<Type disk_latency>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read "
+  DSName write Write
+  RRDTitle "Disk Latency for {plugin_instance}"
+  RRDVerticalLabel "seconds"
+  Scale 0.000001
+  RRDFormat "%5.1lf %ss"
+</Type>
+<Type disk_octets>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Disk Traffic ({instance})"
+  RRDVerticalLabel "Bytes per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type disk_ops>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Disk Operations ({instance})"
+  RRDVerticalLabel "Operations per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf"
+</Type>
+<Type disk_ops_complex>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Netapp disc ops on {plugin_instance}"
+  RRDVerticalLabel "Ops"
+  RRDFormat "%6.2lf"
+  DSName fcp_ops   FCP-Ops
+  DSName nfs_ops   NFS-Ops
+  DSName http_ops  HTTP-Ops
+  DSName cifs_ops  CIFS-Ops
+  DSName dafs_ops  DAFS-Ops
+  DSName iscsi_ops iSCSI-Ops
+  Order fcp_ops nfs_ops http_ops cifs_ops dafs_ops iscsi_ops
+  Color fcp_ops    000080
+  Color nfs_ops    ff0000
+  Color http_ops   ffb000
+  Color cifs_ops   00e0a0
+  Color dafs_ops   00e000
+  Color iscsi_ops  00e0ff
+</Type>
+<Type disk_merged>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Disk Merged Operations ({instance})"
+  RRDVerticalLabel "Merged operations/s"
+# RRDOptions ...
+  RRDFormat "%5.1lf"
+</Type>
+<Type disk_time>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Disk time per operation ({instance})"
+  RRDVerticalLabel "Avg. Time/Op"
+# RRDOptions ...
+  RRDFormat "%5.1lf%ss"
+  Scale 0.001
+</Type>
+<Type disk2_time>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Disk time per operation ({instance})"
+  RRDVerticalLabel "Avg. Time/Op"
+# RRDOptions ...
+  RRDFormat "%5.1lf%ss"
+  Scale 0.001
+</Type>
+<Type dns_opcode>
+  DataSources value
+  DSName "value Queries/s"
+  RRDTitle "DNS Opcode {type_instance}"
+  RRDVerticalLabel "Queries/s"
+  RRDFormat "%6.1lf"
+</Type>
+<Type conntrack>
+  DataSources conntrack
+  DSName conntrack Conntrack count
+  RRDTitle "nf_conntrack connections on {hostname}"
+  RRDVerticalLabel "Count"
+  RRDFormat "%4.0lf"
+</Type>
+<Type entropy>
+  DataSources entropy
+  DSName entropy Entropy bits
+  RRDTitle "Available entropy on {hostname}"
+  RRDVerticalLabel "Bits"
+  RRDFormat "%4.0lf"
+</Type>
+<Type fanspeed>
+  DataSources value
+  DSName value RPM
+  RRDTitle "Fanspeed ({instance})"
+  RRDVerticalLabel "RPM"
+  RRDFormat "%6.1lf"
+  Color value 00b000
+</Type>
+<Type frequency>
+  DataSources frequency
+  DSName frequency Frequency
+  RRDTitle "Frequency ({type_instance})"
+  RRDVerticalLabel "Hertz"
+  RRDFormat "%4.1lfHz"
+  Color frequency a000a0
+</Type>
+<Type humidity>
+  DataSources value
+  DSName value Humitidy
+  RRDTitle "Humitidy ({instance})"
+  RRDVerticalLabel "Percent"
+  RRDFormat "%4.1lf%%"
+  Color value 00e000
+</Type>
+<Type if_errors>
+  Module GenericIO
+  DataSources rx tx
+  DSName rx RX
+  DSName tx TX
+  RRDTitle "Interface Errors ({type_instance})"
+  RRDVerticalLabel "Errors per second"
+# RRDOptions ...
+  RRDFormat "%.3lf"
+</Type>
+<Type if_rx_errors>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Interface receive errors ({plugin_instance})"
+  RRDVerticalLabel "Erorrs/s"
+  RRDFormat "%.1lf"
+  Color length  f00000
+  Color over    00e0ff
+  Color crc     00e000
+  Color frame   ffb000
+  Color fifo    f000c0
+  Color missed  0000f0
+</Type>
+<Type if_tx_errors>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Interface transmit errors ({plugin_instance})"
+  RRDVerticalLabel "Erorrs/s"
+  RRDFormat "%.1lf"
+  Color aborted   f00000
+  Color carrier   00e0ff
+  Color fifo      00e000
+  Color heartbeat ffb000
+  Color window    f000c0
+</Type>
+<Type if_octets>
+  Module GenericIO
+  DataSources rx tx
+  DSName rx RX
+  DSName tx TX
+  RRDTitle "Traffic: {hostname} - {type_instance}"
+  RRDVerticalLabel "Bits per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+  Scale 8
+</Type>
+<Type if_packets>
+  Module GenericIO
+  DataSources rx tx
+  DSName rx RX
+  DSName tx TX
+  RRDTitle "Packets: {hostname} - {type_instance}"
+  RRDVerticalLabel "Packets per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type invocations>
+  DataSources value
+  DSName "value Invocations/s"
+  RRDTitle "Invocations ({instance})"
+  RRDVerticalLabel "Invocations/s"
+  RRDFormat "%5.1lf"
+</Type>
+<Type io_octets>
+  Module GenericIO
+  DataSources rx tx
+  DSName "rx Read   "
+  DSName "tx Written"
+  RRDTitle "IO Traffic ({instance})"
+  RRDVerticalLabel "Bytes per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type ipt_bytes>
+  DataSources value
+  DSName value Bytes/s
+  RRDTitle "Traffic ({type_instance})"
+  RRDVerticalLabel "Bytes per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type ipt_packets>
+  DataSources value
+  DSName value Packets/s
+  RRDTitle "Packets ({type_instance})"
+  RRDVerticalLabel "Packets per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf"
+</Type>
+<Type irq>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Interrupts on {hostname}"
+  RRDVerticalLabel "IRQs/s"
+  RRDFormat "%5.1lf"
+</Type>
+<Type load>
+  Module Load
+</Type>
+<Type java_memory>
+  Module JavaMemory
+  DataSources value
+</Type>
+<Type memory>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Physical memory utilization on {hostname}"
+  RRDVerticalLabel "Bytes"
+  RRDFormat "%5.1lf%s"
+  RRDOptions -b 1024 -l 0
+  DSName     "free Free    "
+  DSName   "cached Cached  "
+  DSName "buffered Buffered"
+  DSName   "locked Locked  "
+  DSName     "used Used    "
+  #Order used buffered cached free
+  Order free cached buffered used
+  Color free      00e000
+  Color cached    0000ff
+  Color buffered  ffb000
+  Color locked    ff00ff
+  Color used      ff0000
+</Type>
+<Type mysql_commands>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "MySQL commands ({plugin_instance})"
+  RRDVerticalLabel "Invocations"
+  RRDFormat "%6.2lf"
+
+
+  DSName admin_commands admin_commands
+  DSName alter_table alter_table
+  DSName begin begin
+  DSName change_db change_db
+  DSName check check
+  DSName commit commit
+  DSName create_db create_db
+  DSName create_table create_table
+  DSName delete delete
+  DSName drop_db drop_db
+  DSName drop_table drop_table
+  DSName flush flush
+  DSName grant grant
+  DSName insert insert
+  DSName insert_select insert_select
+  DSName lock_tables lock_tables
+  DSName optimize optimize
+  DSName rename_table rename_table
+  DSName replace replace
+  DSName revoke revoke
+  DSName select select
+  DSName set_option set_option
+  DSName show_create_table show_create_table
+  DSName show_databases show_databases
+  DSName show_fields show_fields
+  DSName show_keys show_keys
+  DSName show_master_status show_master_status
+  DSName show_processlist show_processlist
+  DSName show_slave_hosts show_slave_hosts
+  DSName show_status show_status
+  DSName show_tables show_tables
+  DSName show_triggers show_triggers
+  DSName show_variables show_variables
+  DSName unlock_tables unlock_tables
+  DSName update update
+  DSName update_multi update_multi
+
+  Order admin_commands alter_table begin change_db check commit create_db create_table delete drop_db drop_table flush grant insert insert_select lock_tables optimize rename_table replace revoke select set_option show_create_table show_databases show_fields show_keys show_master_status show_processlist show_slave_hosts show_status show_tables show_triggers show_variables unlock_tables update update_multi
+
+  Color admin_commands ff0000
+  Color alter_table ff002a
+  Color begin ff0055
+  Color change_db ff007f
+  Color check ff00aa
+  Color commit ff00d4
+  Color create_db ff00ff
+  Color create_table d400ff
+  Color delete aa00ff
+  Color drop_db 7f00ff
+  Color drop_table 5400ff
+  Color flush 2a00ff
+  Color grant 0000ff
+  Color insert 002aff
+  Color insert_select 0055ff
+  Color lock_tables 007fff
+  Color optimize 00a9ff
+  Color rename_table 00d4ff
+  Color replace 00ffff
+  Color revoke 00ffd4
+  Color select 00ffa9
+  Color set_option 00ff7f
+  Color show_create_table 00ff55
+  Color show_databases 00ff2a
+  Color show_fields 00ff00
+  Color show_keys 2aff00
+  Color show_master_status 54ff00
+  Color show_processlist 7fff00
+  Color show_slave_hosts aaff00
+  Color show_status d4ff00
+  Color show_tables ffff00
+  Color show_triggers ffd400
+  Color show_variables ffaa00
+  Color unlock_tables ff7f00
+  Color update ff5400
+  Color update_multi ff2a00
+</Type>
+<Type mysql_handler>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "MySQL handler ({plugin_instance})"
+  RRDVerticalLabel "Invocations"
+  RRDFormat "%6.2lf"
+  DSName commit commit
+  DSName delete delete
+  DSName read_first read_first
+  DSName read_key read_key
+  DSName read_next read_next
+  DSName read_prev read_prev
+  DSName read_rnd read_rnd
+  DSName read_rnd_next read_rnd_next
+  DSName update update
+  DSName write write
+  Order commit delete read_first read_key read_next read_prev read_rnd read_rnd_next update write
+  Color commit ff0000
+  Color delete ff0099
+  Color read_first cc00ff
+  Color read_key 3200ff
+  Color read_next 0065ff
+  Color read_prev 00ffff
+  Color read_rnd 00ff65
+  Color read_rnd_next 33ff00
+  Color update cbff00
+  Color write ff9800
+</Type>
+<Type mysql_octets>
+  Module GenericIO
+  DataSources rx tx
+  DSName rx RX
+  DSName tx TX
+  RRDTitle "MySQL Traffic ({plugin_instance})"
+  RRDVerticalLabel "Bits per second"
+  RRDFormat "%5.1lf%s"
+  Scale 8
+</Type>
+<Type percent>
+  DataSources percent
+  DSName percent Percent
+  RRDTitle "Percent ({type_instance})"
+  RRDVerticalLabel "Percent"
+  RRDFormat "%4.1lf%%"
+  Color percent 0000ff
+</Type>
+<Type ping>
+  DataSources ping
+  DSName "ping Latency"
+  RRDTitle "Network latency ({type_instance})"
+  RRDVerticalLabel "Milliseconds"
+  RRDFormat "%5.2lfms"
+</Type>
+<Type power>
+  DataSources value
+  DSName value Watts
+  RRDTitle "Power ({type_instance})"
+  RRDVerticalLabel "Watts"
+  RRDFormat "%6.2lf%sW"
+  Color value 008080
+</Type>
+<Type ps_cputime>
+  Module PsCputime
+</Type>
+<Type ps_rss>
+  DataSources value
+  DSName value RSS
+  RRDTitle "Resident Segment Size ({instance})"
+  RRDVerticalLabel "Bytes"
+  RRDFormat "%6.2lf%s"
+</Type>
+<Type ps_state>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Processes on {hostname}"
+  RRDVerticalLabel "Processes"
+  RRDFormat "%5.1lf"
+  DSName running  Running
+  DSName sleeping Sleeping
+  DSName paging   Paging
+  DSName zombies  Zombies
+  DSName blocked  Blocked
+  DSName stopped  Stopped
+  Order paging blocked zombies stopped running sleeping
+  Color running  00e000
+  Color sleeping 0000ff
+  Color paging   ffb000
+  Color zombies  ff0000
+  Color blocked  ff00ff
+  Color stopped  a000a0
+</Type>
+<Type swap>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Swap utilization on {hostname}"
+  RRDVerticalLabel "Bytes"
+  RRDFormat "%5.1lf%s"
+  RRDOptions -b 1024 -l 0
+  DSName     "free Free    "
+  DSName   "cached Cached  "
+  DSName     "used Used    "
+  #Order used cached free
+  Order free cached used
+  Color free      00e000
+  Color cached    0000ff
+  Color used      ff0000
+</Type>
+<Type table_size>
+  Module TableSize
+  DataSources value
+  DSName value Bytes
+  RRDTitle "Table size ({instance})"
+  RRDVerticalLabel "Size [Bytes]"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type tcp_connections>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "TCP connections ({plugin_instance})"
+  RRDVerticalLabel "Connections"
+  RRDFormat "%5.1lf"
+  Order LISTEN CLOSING LAST_ACK CLOSE_WAIT CLOSE TIME_WAIT FIN_WAIT2 FIN_WAIT1 SYN_RECV SYN_SENT ESTABLISHED CLOSED
+  Color ESTABLISHED 00e000
+  Color SYN_SENT   00e0ff
+  Color SYN_RECV   00e0a0
+  Color FIN_WAIT1  f000f0
+  Color FIN_WAIT2  f000a0
+  Color TIME_WAIT  ffb000
+  Color CLOSE      0000f0
+  Color CLOSE_WAIT 0000a0
+  Color LAST_ACK   000080
+  Color LISTEN     ff0000
+  Color CLOSING    000000
+  Color CLOSED     0000f0
+</Type>
+<Type temperature>
+  DataSources value
+  DSName value Temp
+  RRDTitle "Temperature ({instance})"
+  RRDVerticalLabel "°Celsius"
+  RRDFormat "%4.1lf°C"
+</Type>
+<Type threads>
+  DataSources value
+  DSName "value Threads"
+  RRDTitle "Threads ({instance})"
+  RRDVerticalLabel "Threads"
+  RRDFormat "%5.2lf"
+</Type>
+<Type total_requests>
+  DataSources value
+  DSName "value Requests/s"
+  RRDTitle "Requests ({instance})"
+  RRDVerticalLabel "Requests/s"
+  RRDFormat "%6.2lf"
+</Type>
+<Type total_time_in_ms>
+  DataSources value
+  DSName "value Time"
+  RRDTitle "Time {instance}"
+  RRDVerticalLabel "Seconds"
+  RRDFormat "%6.2lf %ss"
+  Scale 0.001
+</Type>
+<Type users>
+  DataSources users
+  DSName users Users
+  RRDTitle "Users ({type_instance}) on {hostname}"
+  RRDVerticalLabel "Users"
+  RRDFormat "%.1lf"
+  Color users 0000f0
+</Type>
+<Type voltage>
+  DataSources value
+  DSName value Volts
+  RRDTitle "Voltage ({type_instance})"
+  RRDVerticalLabel "Volts"
+  RRDFormat "%4.1lfV"
+  Color value f00000
+</Type>
+<Type vs_network_syscalls>
+  Module GenericIO
+  DataSources recv send
+  RRDTitle "Syscalls: {hostname} - {type_instance}"
+  RRDVerticalLabel "Calls per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type vs_io_bytes>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "VServer Disk IO ({hostname})"
+  RRDVerticalLabel "Bytes per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf%s"
+</Type>
+<Type vs_io_ops>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "VServer Disk Ops ({hostname})"
+  RRDVerticalLabel "Operations per second"
+# RRDOptions ...
+  RRDFormat "%5.1lf"
+</Type>
+<Type vs_io_time_op>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Avg. Time/Op ({hostname})"
+  RRDVerticalLabel "Avg. Time/Op"
+# RRDOptions ...
+  RRDFormat "%5.1lf%ss"
+  Scale 0.000000001
+</Type>
+<Type vs_io_time>
+  Module GenericIO
+  DataSources read write
+  DSName "read Read   "
+  DSName write Written
+  RRDTitle "Time spent on Ops ({hostname})"
+  RRDVerticalLabel "Time"
+# RRDOptions ...
+  RRDFormat "%5.1lf%ss"
+  Scale 0.000000001
+</Type>
+<Type vs_cpu>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Slice CPU usage - {hostname}"
+  RRDVerticalLabel "Jiffies"
+  RRDFormat "%5.2lf"
+  DSName user User
+  DSName system System
+  DSName onhold OnHold
+  Order user system onhold
+  Color user      0000ff
+  Color system    ff0000
+  Color onhold    00f0f0
+</Type>
+<Type process_cpu>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "Process CPU usage: {plugin_instance} - {hostname}"
+  RRDVerticalLabel "Jiffies"
+  RRDFormat "%5.2lf"
+  DSName user User
+  DSName system System
+  Order user system
+  Color user      0000ff
+  Color system    ff0000
+</Type>
+<Type process_memory>
+  Module GenericStacked
+  DataSources value
+  Stacking off
+  RRDTitle "Process memory: {plugin_instance} - {hostname}"
+  RRDVerticalLabel "Bytes"
+  RRDFormat "%5.1lf%s"
+  RRDOptions -b 1024 -l 0
+  DSName      "vm VirtualMemory "
+  DSName     "rss RSS           "
+  Order vm rss
+  Color rss       ff0000
+  Color vm        00ff00
+</Type>
+<Type vs_memory>
+  Module GenericStacked
+  DataSources value
+  Stacking off
+  RRDTitle "Memory: {hostname}"
+  RRDVerticalLabel "Bytes"
+  RRDFormat "%5.1lf%s"
+  RRDOptions -b 1024 -l 0
+  DSName      "vm VirtualMemory "
+  DSName     "rss RSS           "
+  DSName     "vml Locked        "
+  DSName    "anon Anonymous     "
+  Order vm rss vml anon
+  Color anon      00ffff
+  Color vml       0000ff
+  Color rss       ff0000
+  Color vm        00ff00
+</Type>
+<Type vmpage_number>
+  Module GenericStacked
+  DataSources value
+  Stacking off
+  RRDTitle "Virtual Memory Pages"
+  RRDVerticalLabel "Pages"
+  RRDFormat "%5.1lf%s"
+  RRDOptions -h 512 -w 512 -b 1024 -l 0
+  DSName free_pages
+  DSName anon_pages
+  DSName active_anon
+  DSName inactive_anon
+  DSName isolated_anon 
+
+  DSName file_pages
+  DSName active_file
+  DSName inactive_file
+  DSName isolated_file 
+  DSName slab_reclaimable
+  DSName slab_unreclaimable
+  #Order free_pages anon_pages file_pages active_file inactive_file isolated_file active_anon inactive_anon isolated_anon 
+  #Order vm rss vml anon
+  Color free_pages ff0000
+  Color anon_pages ffff00
+  Color active_anon 0000ff
+  Color inactive_anon 00ff00
+  Color isolated_anon ff00ff
+  Color file_pages 00ffff
+  Color active_file 0000ff
+  Color inactive_file 00ff00
+  Color isolated_file ff00ff
+  Color slab_reclaimable 00ff80
+  Color slab_unreclaimable ff0080
+</Type>
+<Type vs_quota_bytes>
+  Module Df
+  RRDTitle "VS Quota {hostname}"
+  DataSources free used
+</Type>
+<Type vs_threads>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "VS Threads for {plugin_instance}"
+  RRDVerticalLabel "Count"
+  RRDFormat "%5.2lf"
+  DSName onhold OnHold
+  DSName running Running
+  DSName total Total
+  DSName uninterruptable Uninterruptable
+  Order uninterruptable onhold running total
+  Color uninterruptable e8e8e8
+  Color onhold    00e000
+  Color running   0000ff
+  Color total     ffb000
+</Type>
+<Type vs_threads_basic>
+  Module GenericStacked
+  DataSources value
+  RRDTitle "VS Threads for {hostname}"
+  RRDVerticalLabel "Count"
+  RRDFormat "%5.2lf"
+  DSName running Running
+  DSName other Not running
+  Order running other 
+  Color running 0000ff
+  Color other ffb000
+</Type>
+<Type wirkleistung>
+  Module Wirkleistung
+  DataSources kWh
+  DSName value Wh
+  RRDTitle "Watt"
+  RRDVerticalLabel "W"
+  RRDFormat "%4.1lfW"
+</Type>
+# vim: set sw=2 sts=2 et syntax=apache fileencoding=utf-8 :

--- a/viewer/httpd.collectd.conf
+++ b/viewer/httpd.collectd.conf
@@ -1,0 +1,62 @@
+ServerTokens ProductOnly
+ServerRoot "/etc/httpd"
+PidFile run/httpd.pid
+Timeout 60
+KeepAlive Off
+MaxKeepAliveRequests 100
+KeepAliveTimeout 15
+
+Listen 8088
+User apache
+Group apache
+DocumentRoot "/var/www/html"
+
+
+<IfModule prefork.c>
+StartServers       1
+MinSpareServers    1
+MaxSpareServers    1
+ServerLimit      256
+MaxClients       256
+MaxRequestsPerChild  4000
+</IfModule>
+
+
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule cgi_module modules/mod_cgi.so
+
+
+<Files ~ "^\.ht">
+    Order allow,deny
+    Deny from all
+    Satisfy All
+</Files>
+
+TypesConfig /etc/mime.types
+DefaultType text/plain
+
+
+ErrorLog logs/error_log
+LogLevel warn
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+CustomLog logs/access_log combined
+
+
+AddDefaultCharset UTF-8
+AddType application/x-compress .Z
+AddType application/x-gzip .gz .tgz
+
+
+# collectd-web config.
+ScriptAlias /bin/ /usr/share/collectd/collection3/bin/
+Alias / /usr/share/collectd/collection3/
+
+Include /usr/share/collectd-mlab/access.conf

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -75,7 +75,7 @@ def log(msg):
   syslog.syslog(syslog.LOG_ERR, 'mlab-view: %s' % msg)
 
 
-def ignore_signal_handler(signal, frame):
+def ignore_signal_handler(signal, _):
   """Handler to ignore any signal."""
   log('Ignoring signal: %s' % signal)
 

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -110,6 +110,8 @@ def get_access_config():
 def is_running(pid):
   """Checks whether the given pid is running or not."""
   try:
+    # Signal 0 has no effect on a running process, but fails when the
+    # process does not exit.
     os.kill(pid, 0)
     return True
   except OSError:

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -51,6 +51,7 @@ What's happening?
  * SSH continues to forward all traffic back and forth from localhost:8088
    through the ssh connection to the remote web server.
 """
+
 import os
 import signal
 import subprocess

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -107,28 +107,76 @@ def get_access_config():
 """.format(ips=get_address())
 
 
-def find_last_parent(pid):
-  """Walks up process tree starting at pid, stopping at sshd or ppid == 1."""
+def is_running(pid):
+  """Checks whether the given pid is running or not."""
+  try:
+    os.kill(pid, 0)
+    return True
+  except OSError:
+    return False
+
+
+def ssh_connection_has_closed(pid):
+  """Determines whether the ssh session that started pid is still open.
+
+  Callers should check that pid is actually running.
+
+  Args:
+    pid: int, a leaf pid in the process tree started via ssh.
+  Returns:
+    bool, True if the connection has closed, False otherwise.
+  """
+  # From the host context, ps can see the entire process tree. The process tree
+  # runs from sshd in the host context to httpd running in the mlab_utility
+  # slice. For example:
+  #
+  # CONTEXT       PPID   PID COMMAND
+  # MAIN             1  1118 /usr/sbin/sshd
+  # MAIN          1118 10594 sshd: mlab_utility [priv]
+  # MAIN         10594 10606 sshd: mlab_utility@notty
+  # MAIN         10606 10607 /bin/su - mlab_utility -c sudo mlab-view
+  # mlab_utility 10607 10668 sudo mlab-view
+  # mlab_utility 10668 10689 /usr/bin/python /usr/bin/mlab-view
+  # mlab_utility 10689 10692 /usr/sbin/httpd -X -f /usr/share/.../httpd.conf
+  #
+  # From within the mlab_utility slice, ps can only see processes in the slice.
+  #
+  #               PPID   PID COMMAND
+  #              10606 10607 /bin/su - mlab_utility -c sudo mlab-view
+  #              10607 10668 sudo mlab-view
+  #              10668 10689 /usr/bin/python /usr/bin/mlab-view
+  #              10689 10692 /usr/sbin/httpd -X -f /usr/share/.../httpd.conf
+  #
+  # The ppid for /bin/su references an sshd process in the host context, until
+  # the client connection closes. Once the ssh connection closes, the sshd
+  # process exits and the /bin/su parent pid changes to 1.
+  #
+  #               PPID   PID COMMAND
+  #                  1 10607 /bin/su - mlab_utility -c sudo mlab-view
+  #
+  # That change signals that mlab-view should shutdown httpd and exit.
   try:
     status_lines = open('/proc/%s/status' % pid, 'r').readlines()
   except IOError:
-    return -1
+    return False
 
   name_lines = filter(lambda x: x.startswith('Name:'), status_lines)
   if not name_lines:
-    return -1
+    return False
 
   ppid_lines = filter(lambda x: x.startswith('PPid:'), status_lines)
   if not ppid_lines:
-    return -1
+    return False
 
-  # If the process name contains 'sshd', we'll stop there.
+  # To allow running mlab-view from root context, also stop searching when the
+  # process name contains 'sshd'.
   ppid = int(ppid_lines[0].split()[1])
   if 'sshd' in name_lines[0] or ppid == 1:
-    return ppid
+    # If the parent pid is 1, then the connection has closed.
+    return ppid == 1
 
-  # Continue up the tree.
-  return find_last_parent(ppid)
+  # Continue up the process tree.
+  return ssh_connection_has_closed(ppid)
 
 
 def main():
@@ -157,12 +205,12 @@ def main():
   log('Started web server pid:%s' % child.pid)
   pid = os.getpid()
   while True:
-    ppid = find_last_parent(pid)
-    if ppid == 1:
-      # When started via ssh, there is a chain of processes from sshd to the
-      # web server. When the ssh session ends, the first child's parent is set
-      # to pid 1. Once this occurs, no one is interacting with server.  So,
-      # kill the server.
+    if not is_running(pid):
+      break
+
+    if ssh_connection_has_closed(pid):
+      # When the ssh session ends, no one is interacting with server, so
+      # shutdown the server.
       break
     time.sleep(1)
 

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -64,7 +64,10 @@ import netifaces
 
 
 ACCESS_CONF = '/usr/share/collectd-mlab/access.conf'
+HTTPD_BIN = '/usr/sbin/httpd'
+HTTPD_CONFIG = '/usr/share/collectd-mlab/httpd.conf'
 HTTPD_PID = '/etc/httpd/run/httpd.pid'
+
 
 def log(msg):
   """Sends log message to syslog."""
@@ -79,9 +82,8 @@ def ignore_signal_handler(signal, frame):
 
 def get_address():
   """Returns local IPv4 & IPv6 addresses as a string separated by spaces."""
-  ifaces = netifaces.interfaces()
   addrs = []
-  for iface in ifaces:
+  for iface in netifaces.interfaces():
     if iface == 'lo':
       continue
     addresses = netifaces.ifaddresses(iface)
@@ -99,8 +101,8 @@ def get_access_config():
     AddHandler cgi-script .cgi
     DirectoryIndex bin/index.cgi
     Order Deny,Allow
-    Allow from {ips}
     Deny from all
+    Allow from {ips}
 </Directory>
 """.format(ips=get_address())
 
@@ -112,17 +114,17 @@ def find_last_parent(pid):
   except IOError:
     return -1
 
+  name_lines = filter(lambda x: x.startswith('Name:'), status_lines)
+  if not name_lines:
+    return -1
+
+  ppid_lines = filter(lambda x: x.startswith('PPid:'), status_lines)
+  if not ppid_lines:
+    return -1
+
   # If the process name contains 'sshd', we'll stop there.
-  name_line = filter(lambda x: x.startswith('Name:'), status_lines)
-  if not name_line:
-    return -1
-
-  ppid_line = filter(lambda x: x.startswith('PPid:'), status_lines)
-  if not ppid_line:
-    return -1
-
-  ppid = int(ppid_line[0].split()[1])
-  if 'sshd' in name_line[0] or ppid == 1:
+  ppid = int(ppid_lines[0].split()[1])
+  if 'sshd' in name_lines[0] or ppid == 1:
     return ppid
 
   # Continue up the tree.
@@ -145,7 +147,7 @@ def main():
     sys.exit(1)
 
   # TODO: what other options are available for serving the cgi files?
-  args = ['/usr/sbin/httpd', '-X', '-f', '/usr/share/collectd-mlab/httpd.conf']
+  args = [HTTPD_BIN, '-X', '-f', HTTPD_CONFIG]
   try:
     child = subprocess.Popen(args)
   except OSError as err:

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -180,7 +180,7 @@ def ssh_connection_has_closed(pid):
 
 
 def main():
-  signal.signal(signal.SIGINT, ignore_signal_handler)
+  # Ignore signals forwarded by pseudo-ttys allocated by ssh.
   signal.signal(signal.SIGTERM, ignore_signal_handler)
 
   try:

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+# Copyright 2014 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Summary:
+  mlab-view provides a limited web server to view the collectd-web CGI scripts.
+
+  While mlab-view is running, an operator can only access the CGI scripts using
+  an SSH tunnel. Direct web connections are refused with "403 Forbidden."
+
+  mlab-view should only be used for debugging and node triage. When a node is
+  in normal operation, mlab-view should not be running. mlab-view guarantees
+  that the web server is shutdown when the operator's ssh connection has
+  disconnected.
+
+Example usage (from operator's workstation):
+
+  $ ssh -L 8088:utility.mlab.<hostname>:8088 \\
+      -p806 mlab_utility@<hostname> sudo mlab-view
+
+  Operator directs their browser to:
+
+      http://localhost:8088/
+
+What's happening?
+
+ * SSH binds to port 8088 on localhost.
+ * SSH login to <hostname> as the mlab_utility user and runs the command:
+
+     "sudo mlab-view".
+
+ * mlab-view starts a web server that listens on port 8088.
+ * The web server is configured to reject connections from any address other
+   than the slice IP.
+ * When ssh detects a connection to localhost:8088, the remote end attempts a
+   connection to:
+
+      "utility.mlab.<hostname>:8088"
+
+   To the server, this connection appears to come from the slice IP.
+ * SSH continues to forward all traffic back and forth from localhost:8088
+   through the ssh connection to the remote web server.
+"""
+import os
+import signal
+import subprocess
+import syslog
+import time
+
+# Third-party modules.
+import netifaces
+
+
+ACCESS_CONF = '/usr/share/collectd-mlab/access.conf'
+HTTPD_PID = '/etc/httpd/run/httpd.pid'
+
+def log(msg):
+  """Sends log message to syslog."""
+  print msg
+  syslog.syslog(syslog.LOG_ERR, 'mlab-view: %s' % msg)
+
+
+def ignore_signal_handler(signal, frame):
+  """Handler to ignore any signal."""
+  log('Ignoring signal: %s' % signal)
+
+
+def get_ipv4_address():
+  """Returns the local IPv4 addresses as a string."""
+  ifaces = netifaces.interfaces()
+  for iface in ifaces:
+    if iface == 'lo':
+      continue
+    addrs = netifaces.ifaddresses(iface)
+    if netifaces.AF_INET in addrs:
+      addrs = [addr['addr'] for addr in addrs[netifaces.AF_INET]]
+      return ' '.join(addrs)
+  return '127.0.0.1'
+
+
+def get_access_config():
+  return """
+<Directory /usr/share/collectd/>
+    AddHandler cgi-script .cgi
+    DirectoryIndex bin/index.cgi
+    Order Deny,Allow
+    Allow from {ipv4}
+    Deny from all
+</Directory>
+""".format(ipv4=get_ipv4_address())
+
+
+def find_last_parent(pid):
+  """Walks up process tree starting at pid, stopping at sshd or ppid == 1."""
+  try:
+    status_lines = open('/proc/%s/status' % pid, 'r').readlines()
+  except IOError:
+    return -1
+
+  # If the process name contains 'sshd', we'll stop there.
+  name_line = filter(lambda x: x.startswith('Name:'), status_lines)
+  if not name_line:
+    return -1
+
+  ppid_line = filter(lambda x: x.startswith('PPid:'), status_lines)
+  if not ppid_line:
+    return -1
+
+  ppid = int(ppid_line[0].split()[1])
+  if 'sshd' in name_line[0] or ppid == 1:
+    return ppid
+
+  # Continue up the tree.
+  return find_last_parent(ppid)
+
+
+def main():
+  signal.signal(signal.SIGINT, ignore_signal_handler)
+  signal.signal(signal.SIGTERM, ignore_signal_handler)
+
+  try:
+    # Unconditionally write httpd access rule with local IP address.
+    open(ACCESS_CONF, 'w').write(get_access_config())
+  except IOError as err:
+    log(err)
+    sys.exit(1)
+
+  if os.path.exists(HTTPD_PID):
+    log('httpd pid file present. Is httpd already running?')
+    sys.exit(1)
+
+  # TODO: what other options are available for serving the cgi files?
+  args = ['/usr/sbin/httpd', '-X', '-f', '/usr/share/collectd-mlab/httpd.conf']
+  try:
+    child = subprocess.Popen(args)
+  except OSError as err:
+    log(err)
+    sys.exit(1)
+
+  log('Started web server pid:%s' % child.pid)
+  pid = os.getpid()
+  while True:
+    ppid = find_last_parent(pid)
+    if ppid == 1:
+      # When started via ssh, there is a chain of processes from sshd to the
+      # web server. When the ssh session ends, the first child's parent is set
+      # to pid 1. Once this occurs, no one is interacting with server.  So,
+      # kill the server.
+      break
+    time.sleep(1)
+
+  log('Killing web server pid:%s' % child.pid)
+  child.kill()
+  try:
+    os.remove(HTTPD_PID)
+  except OSError:
+    pass
+
+
+if __name__ == '__main__':
+  main()

--- a/viewer/mlab-view
+++ b/viewer/mlab-view
@@ -55,6 +55,7 @@ What's happening?
 import os
 import signal
 import subprocess
+import sys
 import syslog
 import time
 
@@ -76,17 +77,20 @@ def ignore_signal_handler(signal, frame):
   log('Ignoring signal: %s' % signal)
 
 
-def get_ipv4_address():
-  """Returns the local IPv4 addresses as a string."""
+def get_address():
+  """Returns local IPv4 & IPv6 addresses as a string separated by spaces."""
   ifaces = netifaces.interfaces()
+  addrs = []
   for iface in ifaces:
     if iface == 'lo':
       continue
-    addrs = netifaces.ifaddresses(iface)
-    if netifaces.AF_INET in addrs:
-      addrs = [addr['addr'] for addr in addrs[netifaces.AF_INET]]
-      return ' '.join(addrs)
-  return '127.0.0.1'
+    addresses = netifaces.ifaddresses(iface)
+    for addr_type in (netifaces.AF_INET, netifaces.AF_INET6):
+      if addr_type in addresses:
+        addrs.extend([addr['addr'] for addr in addresses[addr_type]])
+  if not addrs:
+    return '127.0.0.1'
+  return ' '.join(addrs)
 
 
 def get_access_config():
@@ -95,10 +99,10 @@ def get_access_config():
     AddHandler cgi-script .cgi
     DirectoryIndex bin/index.cgi
     Order Deny,Allow
-    Allow from {ipv4}
+    Allow from {ips}
     Deny from all
 </Directory>
-""".format(ipv4=get_ipv4_address())
+""".format(ips=get_address())
 
 
 def find_last_parent(pid):


### PR DESCRIPTION
This pull request adds mlab-view, a command line utility for limited support of collectd-web CGI scripts.

This change includes:
* the mlab-view command.
* an update to the collectd-mlab.spec to removes references to httpd-config.py (now combined with mlab-view).
* a minimal httpd.conf, used by mlab-view.
* a collection-mlab.conf to provide human-readable names for custom metrics collected by the mlab plugin. 