### PR TITLE
Increase value range for vs_quota_bytes

### DIFF
--- a/plugin/types.db
+++ b/plugin/types.db
@@ -3,7 +3,7 @@ process_memory		value:GAUGE:0:4294967295
 timer			value:GAUGE:0:U
 vs_cpu			value:DERIVE:0:4294967295
 vs_network_syscalls	recv:COUNTER:0:4294967295, send:COUNTER:0:4294967295
-vs_quota_bytes		used:GAUGE:0:4294967295, free:GAUGE:0:4294967295
+vs_quota_bytes		used:GAUGE:0:18446744073709551615, free:GAUGE:0:18446744073709551615
 vs_threads_basic	value:GAUGE:0:65535
 vs_uptime		value:GAUGE:0:4294967295
 vs_vlimit		value:GAUGE:0:4294967295


### PR DESCRIPTION
Actual vserver quota values are larger than 32-bit int. This change increases vs_quota_bytes maximum to 64-bit int value.