### PR TITLE
Add a collectd watchdog and corrupt RRD cleanup.

### DIFF
--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -65,6 +65,8 @@ install -D -m 755 export/mlab_export_cleanup.cron	%{buildroot}/etc/cron.daily/ml
 install -D -m 644 export/mlab_export.cron		%{buildroot}/etc/cron.d/mlab_export.cron
 install -D -m 755 export/mlab_export.py			%{buildroot}/usr/bin/mlab_export.py
 install -D -m 644 export/export_metrics.conf		%{buildroot}/usr/share/collectd-mlab/export_metrics.conf
+install -D -m 644 export/mlab_collectd_watchdog.cron	%{buildroot}/etc/cron.d/mlab_collectd_watchdog.cron
+install -D -m 755 export/mlab_collectd_watchdog.sh		%{buildroot}/usr/share/collectd-mlab/mlab_collectd_watchdog.sh
 
 # Configuration for *limited* access to collectd-web.
 install -D -m 755 viewer/mlab-view 			%{buildroot}/usr/bin/mlab-view
@@ -99,7 +101,9 @@ rm -rf $RPM_BUILD_ROOT
 # Data export scripts.
 /usr/bin/mlab_export.py
 /usr/share/collectd-mlab/export_metrics.conf
+/usr/share/collectd-mlab/mlab_collectd_watchdog.sh
 /etc/cron.d/mlab_export.cron
+/etc/cron.d/mlab_collectd_watchdog.cron
 /etc/cron.daily/mlab_export_cleanup.cron
 
 # Configuration for *limited* access to collectd-web.

--- a/export/mlab_collectd_watchdog.cron
+++ b/export/mlab_collectd_watchdog.cron
@@ -1,0 +1,6 @@
+#
+# Run watchdog every five minutes to guarantee that collectd is running.
+#
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+
+*/5 * * * * root  flock --exclusive --nonblock /tmp/mlab_collectd_watchdog.lock -c /usr/share/collectd-mlab/mlab_collectd_watchdog.sh > /dev/null

--- a/export/mlab_collectd_watchdog.sh
+++ b/export/mlab_collectd_watchdog.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#
+# The collectd watchdog will restart collectd if it is not running and confirm
+# that no RRD files are corrupted. This script should be scheduled to run via
+# cron every few minutes.
+#
+#     */5 * * * * root   flock -xn /tmp/lock -c /usr/bin/mlab_collectd_watchdog.sh > /dev/null
+#
+# The use of 'flock' guarantees that only one instance of the script will run at
+# a time.
+#
+# RRD files created by collectd can become corrupted under some circumstances:
+# bad disk, unscheduled shutdown, gremlins. Corrupted RRD files can crash
+# collectd. So, if collectd is not running, we check all RRD files under
+# /var/lib/collectd/rrd and remove any corrupted files.
+#
+# All file removals are logged in /var/log/mlab-collectd-watchdog.log* on a
+# monthly rotation.
+
+COLLECTD_PATTERN="/usr/sbin/collectd"
+COLLECTD_RRDDIR="/var/lib/collectd/rrd"
+# Rotate log monthly.
+LOGFILE=/var/log/mlab-collectd-watchdog.log.$( date +%m )
+
+# Checks the integrity of all RRD files in rrddir. Corrupt RRDs are removed and
+# log message is written to LOGFILE.
+#
+# Arguments:
+#  rrddir: directory name, recursively check all RRD files under this directory.
+# Returns:
+#  None.
+function check_rrd_integrity () {
+  local rrddir=$1
+  local rrdfile=
+
+  # For all files ending with .rrd under the path $rrddir.
+  for rrdfile in $( find ${rrddir} -name "*.rrd" ); do
+    # If dumping the rrd file fails,
+    if ! rrdtool dump ${rrdfile} > /dev/null ; then
+      # then log the file name and remove it.
+      echo "$(date): Removing corrupt RRD: ${rrdfile}" >> ${LOGFILE}
+      rm -f ${rrdfile} \
+        || echo "$(date): Failed to remove: ${rrdfile}" >> ${LOGFILE}
+    fi
+  done
+}
+
+function start_collectd () {
+  echo "$(date): Starting collectd." >> ${LOGFILE}
+  service collectd start \
+    || echo "$(date): Failed to start collectd." >> ${LOGFILE}
+}
+
+# If collectd is not running, check RRD file integrity and restart.
+if ! pgrep -f ${COLLECTD_PATTERN} > /dev/null ; then
+  check_rrd_integrity ${COLLECTD_RRDDIR}
+  start_collectd
+fi


### PR DESCRIPTION
This change addresses issue #14.

Collectd will crash if RRD files become corrupt. This change adds a
watchdog script that will run every five minutes and check if collectd
is running. If it is not, then an integrity check is performed on all
RRD files and collectd is restarted.

This change also adds the watchdog scripts to the collectd-mlab package.