### PR TITLE
Use log filename format supported by collection pipeline.

### DIFF
--- a/export/mlab_export.py
+++ b/export/mlab_export.py
@@ -289,7 +289,7 @@ def default_output_name(ts_start, ts_end, output_dir):
 
   Filenames are formatted with time stamps as:
       <output_dir>/resource-utilization/YYYY/MM/DD/<HOSTNAME>/
-          metrics-<ts_start>-to-<ts_end>.json
+          <ts_start>-to-<ts_end>-metrics.json
 
   The YYYY, MM, DD in the path are taken from ts_start.
   Both <ts_start> and <ts_end> are formatted as: YYYYMMDDTHHMMSS
@@ -301,9 +301,9 @@ def default_output_name(ts_start, ts_end, output_dir):
   Returns:
     str, absolute path of generated output file name.
   """
-  filename = 'metrics-%s-to-%s.json' % (
-      time.strftime('%Y%m%dT%H%M%S', time.localtime(ts_start)),
-      time.strftime('%Y%m%dT%H%M%S', time.localtime(ts_end)))
+  filename = '%s-to-%s-metrics.json' % (
+      time.strftime('%Y%m%dT%H:%M:%S', time.localtime(ts_start)),
+      time.strftime('%Y%m%dT%H:%M:%S', time.localtime(ts_end)))
   date_path = time.strftime('%Y/%m/%d', time.localtime(ts_start))
   full_path = os.path.join(
       output_dir, 'resource-utilization', date_path, HOSTNAME)

--- a/export/mlab_export_test.py
+++ b/export/mlab_export_test.py
@@ -172,7 +172,7 @@ class MlabExport_GlobalTests(unittest.TestCase):
   def testunit_default_output_name(self):
     mlab_export.HOSTNAME = 'mlab2.nuq0t'
     expected_value = ('/output/resource-utilization/2014/09/06/mlab2.nuq0t/'
-                      'metrics-20140906T105640-to-20140906T115640.json')
+                      '20140906T10:56:40-to-20140906T11:56:40-metrics.json')
     start = FAKE_TIMESTAMP
     end = start + 3600
 
@@ -266,7 +266,8 @@ class MlabExport_GlobalTests(unittest.TestCase):
     expected_files = [rrd_dir + '/mlab2.nuq0t/file2.rrd',
                       rrd_dir + '/mlab2.nuq0t/file1.rrd']
 
-    self.assertEqual(mlab_export.get_rrd_files(rrd_dir), expected_files)
+    self.assertSequenceEqual(sorted(mlab_export.get_rrd_files(rrd_dir)),
+                             sorted(expected_files))
 
   @mock.patch('mlab_export.get_rrd_files')
   @mock.patch('mlab_export.rrdtool.fetch')


### PR DESCRIPTION
This PR updates the log filename format to match the pattern used by the
collection pipeline to match valid log files.

This is a prerequisite for updating the collection pipeline to save
collectd logs to cloud storage.