### PR TITLE
Rename directory name for exported files.

### DIFF
--- a/export/mlab_export.py
+++ b/export/mlab_export.py
@@ -288,7 +288,7 @@ def default_output_name(ts_start, ts_end, output_dir):
   """Creates a default output filename based on time range and output dir.
 
   Filenames are formatted with time stamps as:
-      <output_dir>/resource-utilization/YYYY/MM/DD/<HOSTNAME>/
+      <output_dir>/utilization/YYYY/MM/DD/<HOSTNAME>/
           metrics-<ts_start>-to-<ts_end>.json
 
   The YYYY, MM, DD in the path are taken from ts_start.
@@ -306,7 +306,7 @@ def default_output_name(ts_start, ts_end, output_dir):
       time.strftime('%Y%m%dT%H%M%S', time.localtime(ts_end)))
   date_path = time.strftime('%Y/%m/%d', time.localtime(ts_start))
   full_path = os.path.join(
-      output_dir, 'resource-utilization', date_path, HOSTNAME)
+      output_dir, 'utilization', date_path, HOSTNAME)
   return os.path.join(full_path, filename)
 
 

--- a/export/mlab_export_cleanup.cron
+++ b/export/mlab_export_cleanup.cron
@@ -8,7 +8,7 @@
 # Rotate log over last week.
 LOG=$(( $(date +%j) % 7 ))
 LOGFILE=/var/log/mlab-export-cleanup.log.${LOG}
-RSYNCDIR=/var/spool/mlab_utility/resource-utilization
+RSYNCDIR=/var/spool/mlab_utility/utilization
 
 # Find all files with mtime older than 30 days (+29), print, and remove file.
 find "${RSYNCDIR}" -type f -mtime +29 -a -print -delete &> $LOGFILE

--- a/export/mlab_export_test.py
+++ b/export/mlab_export_test.py
@@ -171,7 +171,7 @@ class MlabExport_GlobalTests(unittest.TestCase):
 
   def testunit_default_output_name(self):
     mlab_export.HOSTNAME = 'mlab2.nuq0t'
-    expected_value = ('/output/resource-utilization/2014/09/06/mlab2.nuq0t/'
+    expected_value = ('/output/utilization/2014/09/06/mlab2.nuq0t/'
                       'metrics-20140906T105640-to-20140906T115640.json')
     start = FAKE_TIMESTAMP
     end = start + 3600


### PR DESCRIPTION
The original directory name was too long. This PR shortens "resource-utilization" to simply "utilization".