### PR TITLE
Disable metrics that are known to be unreliable.

### DIFF
--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -3,7 +3,7 @@
 #
 %define name collectd-mlab
 %define slicename mlab_utility
-%define version 0.999
+%define version 1.0
 %define taglevel alpha
 %define releasetag %{taglevel}%{?date:.%{date}}
 

--- a/export/export_metrics.conf
+++ b/export/export_metrics.conf
@@ -75,14 +75,14 @@ memory.vs_memory-rss:                  memory.rss
 memory.vs_memory-vm:                   memory.vsize
 memory.vs_memory-vml:                  memory.vsize_locked
 
-network.if_octets-ipv4.rx:             network.ipv4.bytes.rx
-network.if_octets-ipv4.tx:             network.ipv4.bytes.tx
-network.if_octets-ipv6.rx:             network.ipv6.bytes.rx
-network.if_octets-ipv6.tx:             network.ipv6.bytes.tx
-network.vs_network_syscalls-ipv4.recv: network.ipv4.syscalls.recv
-network.vs_network_syscalls-ipv4.send: network.ipv4.syscalls.send
-network.vs_network_syscalls-ipv6.recv: network.ipv6.syscalls.recv
-network.vs_network_syscalls-ipv6.send: network.ipv6.syscalls.send
+# network.if_octets-ipv4.rx:             network.ipv4.bytes.rx
+# network.if_octets-ipv4.tx:             network.ipv4.bytes.tx
+# network.if_octets-ipv6.rx:             network.ipv6.bytes.rx
+# network.if_octets-ipv6.tx:             network.ipv6.bytes.tx
+# network.vs_network_syscalls-ipv4.recv: network.ipv4.syscalls.recv
+# network.vs_network_syscalls-ipv4.send: network.ipv4.syscalls.send
+# network.vs_network_syscalls-ipv6.recv: network.ipv6.syscalls.recv
+# network.vs_network_syscalls-ipv6.send: network.ipv6.syscalls.send
 
 processes.fork_rate:                   system.fork_rate
 


### PR DESCRIPTION
Before enabling log collection, this change disables export of the metrics that were discovered to be unreliable in issue #20.