### PR TITLE
Fix root cause of yapf hang.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,15 +15,15 @@ install:
     - pip install yapf==0.7.0
     - pip install pylint==1.5.5
 script:
-    # YAPF must be first or it causes Travis to hang for some reason.
-    - yapf --diff --recursive --style google ./ --exclude=./third_party/*
-    # Run static analysis for Python bugs/cruft.
-    - pyflakes  .
     # Run unit tests
     - python -m unittest discover -s export/ -p '*_test.py'
     - python -m unittest discover -s monitoring/ -p '*_test.py'
     - python -m unittest discover -s plugin/ -p '*_test.py'
     - python -m unittest discover -s system/vsys/ -p '*_test.py'
+    # Run auto formatter.
+    - yapf --diff --recursive --style google ./ --exclude=./third_party/*
+    # Run static analysis for Python bugs/cruft.
+    - pyflakes ./
     # Run the docstring lint checker.
     - PYTHONPATH=$PYTHONPATH:$PWD/third_party/docstringchecker pylint --reports=n plugin/*.py export/*.py monitoring/*.py system/vsys/*.py
 sudo: false

--- a/plugin/mlab_test.py
+++ b/plugin/mlab_test.py
@@ -335,8 +335,10 @@ class MlabCollectdPlugin_VsysFrontendWithoutBackendTests(unittest.TestCase):
         (fifo_in, fifo_out) = mlab.get_vsys_fifo_names('mock_target')
         if not os.path.exists(fifo_in):
             os.mkfifo(fifo_in)
+            self.addCleanup(os.remove, fifo_in)
         if not os.path.exists(fifo_out):
             os.mkfifo(fifo_out)
+            self.addCleanup(os.remove, fifo_out)
 
     @mock.patch('os.open')
     def testunit_open_RAISES_OSError(self, mock_open):
@@ -369,8 +371,10 @@ class MlabCollectdPlugin_VsysFrontendTests(unittest.TestCase):
         (fifo_in, fifo_out) = mlab.get_vsys_fifo_names('mock_target')
         if not os.path.exists(fifo_in):
             os.mkfifo(fifo_in)
+            self.addCleanup(os.remove, fifo_in)
         if not os.path.exists(fifo_out):
             os.mkfifo(fifo_out)
+            self.addCleanup(os.remove, fifo_out)
         self.backend = FakeVsysBackend('mock_target')
         self.backend.start()
 
@@ -891,8 +895,10 @@ class MlabCollectdPlugin_IntegrationTests(unittest.TestCase):
         (fifo_in, fifo_out) = mlab.get_vsys_fifo_names('mock_target')
         if not os.path.exists(fifo_in):
             os.mkfifo(fifo_in)
+            self.addCleanup(os.remove, fifo_in)
         if not os.path.exists(fifo_out):
             os.mkfifo(fifo_out)
+            self.addCleanup(os.remove, fifo_out)
         FakeValues.setup()
 
     def tearDown(self):


### PR DESCRIPTION
The collectd plugin/mlab_test would create mock fifos but not remove them. While the tests could rerun safely, some interaction between mlab_test.py and yapf caused hangs. Cleaning up the fifos prevents the hangs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/31)
<!-- Reviewable:end -->
