### PR TITLE
Add "simple session" module and tests.

### DIFF
--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -1,7 +1,17 @@
-"""A simple session interface."""
+"""A simple interface for SNMP sessions."""
 
 import collections
 import netsnmp
+
+
+class Error(Exception):
+    """Base error class for simple_session module."""
+    pass
+
+
+class SNMPError(Error):
+    """A netsnmp error occurred."""
+    pass
 
 
 class SimpleSession(object):
@@ -22,10 +32,17 @@ class SimpleSession(object):
         list is returned.
 
         Returns:
-          list of dict, with each dict containing a 'tag' and 'val' keys.
+          list of dict, with each dict containing 'tag' and 'val' keys.
+
+        Raises:
+          SNMPError: netsnmp session reports any error.
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.get(oids)
+        if self._session.ErrorStr:
+            raise SNMPError('%s: %s' % (self._session.ErrorStr,
+                                        self._session.ErrorInd))
+
         return self._varlist_to_list(oids)
 
     def walk(self, oid):
@@ -36,9 +53,15 @@ class SimpleSession(object):
 
         Returns:
           list of dict, with each dict containing a 'tag' and 'val' keys.
+
+        Raises:
+          SNMPError: netsnmp session reports any error.
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.walk(oids)
+        if self._session.ErrorStr:
+            raise SNMPError('%s: %s' % (self._session.ErrorStr,
+                                        self._session.ErrorInd))
         return self._varlist_to_list(oids)
 
     def _varlist_to_list(self, oids):
@@ -46,7 +69,7 @@ class SimpleSession(object):
         # The oid.val attribute starts as None and is set after a successful
         # request. If it is still None, then the request failed and it should
         # be excluded from the return value.
-        return [{'tag': oid.tag,
+        return [{'tag': oid.tag + ('.' + oid.iid if oid.iid else ''),
                  'val': oid.val} for oid in oids if oid.val is not None]
 
 
@@ -54,14 +77,14 @@ class FakeSession(object):
     """Implements a fake SimpleSession interface for tests."""
 
     def __init__(self):
-        self._mibs = collections.defaultdict(list)
+        self._mib = collections.defaultdict(list)
 
-    def prepare(self, oid, key, val):
-        """Associates an OID with a key,value for later calls to get or walk."""
-        self._mibs[oid].append({'tag': key, 'val': val})
+    def prepare(self, oid, tag, val):
+        """Associates an OID with a tag,value for later calls to get or walk."""
+        self._mib[oid].append({'tag': tag, 'val': val})
 
-    def get(self, mib):
-        return self._mibs.get(mib, [])
+    def get(self, oid):
+        return self._mib[oid]
 
-    def walk(self, mib):
-        return self._mibs.get(mib, [])
+    def walk(self, oid):
+        return self._mib[oid]

--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -1,6 +1,7 @@
 """A simple interface for SNMP sessions."""
 
 import collections
+# TODO(soltesz): replace netsnmp with easysnmp when available.
 import netsnmp
 
 
@@ -10,8 +11,22 @@ class Error(Exception):
 
 
 class SNMPError(Error):
-    """A netsnmp error occurred."""
+    """A netsnmp error occurred or no results returned."""
     pass
+
+
+# TODO(soltesz): replace SNMPVariable with easysnmp.SNMPVariable when available.
+class SNMPVariable(object):
+    """An SNMP variable representing the result of a get or walk query.
+
+    Attributes:
+        oid: str, the OID of the variable.
+        value: str, the OID value.
+    """
+
+    def __init__(self, oid, value):
+        self.oid = oid
+        self.value = value
 
 
 class SimpleSession(object):
@@ -32,18 +47,14 @@ class SimpleSession(object):
         list is returned.
 
         Returns:
-          list of dict, with each dict containing 'tag' and 'val' keys.
+          list of SNMPVariable, the results of the get request.
 
         Raises:
-          SNMPError: netsnmp session reports any error.
+          SNMPError: netsnmp session reports any error, or no result from get.
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.get(oids)
-        if self._session.ErrorStr:
-            raise SNMPError('%s: %s' % (self._session.ErrorStr,
-                                        self._session.ErrorInd))
-
-        return self._varlist_to_list(oids)
+        return self._handle_result(oid, oids)
 
     def walk(self, oid):
         """Reads all values in the MIB tree starting at the given OID.
@@ -52,25 +63,36 @@ class SimpleSession(object):
         list is returned.
 
         Returns:
-          list of dict, with each dict containing a 'tag' and 'val' keys.
+          list of SNMPVariable, the results of the walk request.
 
         Raises:
-          SNMPError: netsnmp session reports any error.
+          SNMPError: netsnmp session reports any error, or no results from walk.
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.walk(oids)
+        return self._handle_result(oid, oids)
+
+    def _handle_result(self, oid, oids):
+        """Converts results in oids, or raises exceptions for errors."""
         if self._session.ErrorStr:
-            raise SNMPError('%s: %s' % (self._session.ErrorStr,
-                                        self._session.ErrorInd))
-        return self._varlist_to_list(oids)
+            raise SNMPError('netsnmp error; %s: %s' % (self._session.ErrorStr,
+                                                       self._session.ErrorInd))
+        result = self._varlist_to_list(oids)
+        if not result:
+            raise SNMPError('netsnmp error unknown; OID may be invalid: ' + oid)
+        return result
 
     def _varlist_to_list(self, oids):
-        """Converts a netsnmp.Varlist to a list of dict."""
+        """Converts a netsnmp.Varlist to a list of SNMPVariable."""
         # The oid.val attribute starts as None and is set after a successful
         # request. If it is still None, then the request failed and it should
         # be excluded from the return value.
-        return [{'tag': oid.tag + ('.' + oid.iid if oid.iid else ''),
-                 'val': oid.val} for oid in oids if oid.val is not None]
+        result = []
+        for oid in oids:
+            if oid.val is not None:
+                tag = oid.tag + ('.' + oid.iid if oid.iid else '')
+                result.append(SNMPVariable(tag, oid.val))
+        return result
 
 
 class FakeSession(object):
@@ -79,9 +101,9 @@ class FakeSession(object):
     def __init__(self):
         self._mib = collections.defaultdict(list)
 
-    def prepare(self, oid, tag, val):
+    def prepare(self, oid, tag, value):
         """Associates an OID with a tag,value for later calls to get or walk."""
-        self._mib[oid].append({'tag': tag, 'val': val})
+        self._mib[oid].append(SNMPVariable(tag, value))
 
     def get(self, oid):
         return self._mib[oid]

--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -1,0 +1,67 @@
+"""A simple session interface."""
+
+import collections
+import netsnmp
+
+
+class SimpleSession(object):
+    """A simpler session interface for netsnmp.Session."""
+
+    def __init__(self, session):
+        """Creates a SimpleSession object.
+
+        Args:
+          session: netsnmp.Session, the SNMP session to use for queries.
+        """
+        self._session = session
+
+    def get(self, oid):
+        """Reads the value at the given OID.
+
+        If an error occurs such that the get could not be completed, an empty
+        list is returned.
+
+        Returns:
+          list of dict, with each dict containing a 'tag' and 'val' keys.
+        """
+        oids = netsnmp.VarList(netsnmp.Varbind(oid))
+        self._session.get(oids)
+        return self._varlist_to_list(oids)
+
+    def walk(self, oid):
+        """Reads all values in the MIB tree starting at the given OID.
+
+        If an error occurs such that the walk could not be completed, an empty
+        list is returned.
+
+        Returns:
+          list of dict, with each dict containing a 'tag' and 'val' keys.
+        """
+        oids = netsnmp.VarList(netsnmp.Varbind(oid))
+        self._session.walk(oids)
+        return self._varlist_to_list(oids)
+
+    def _varlist_to_list(self, oids):
+        """Converts a netsnmp.Varlist to a list of dict."""
+        # The oid.val attribute starts as None and is set after a successful
+        # request. If it is still None, then the request failed and it should
+        # be excluded from the return value.
+        return [{'tag': oid.tag,
+                 'val': oid.val} for oid in oids if oid.val is not None]
+
+
+class FakeSession(object):
+    """Implements a fake SimpleSession interface for tests."""
+
+    def __init__(self):
+        self._mibs = collections.defaultdict(list)
+
+    def prepare(self, oid, key, val):
+        """Associates an OID with a key,value for later calls to get or walk."""
+        self._mibs[oid].append({'tag': key, 'val': val})
+
+    def get(self, mib):
+        return self._mibs.get(mib, [])
+
+    def walk(self, mib):
+        return self._mibs.get(mib, [])

--- a/site-packages/mlab/disco/simple_session_test.py
+++ b/site-packages/mlab/disco/simple_session_test.py
@@ -10,21 +10,17 @@ import mock
 import simple_session
 
 
-def make_varbind(tag, val):
-    var = netsnmp.Varbind(tag)
-    var.val = val
-    return var
-
-
 @mock.patch.object(netsnmp, 'Varbind')
 @mock.patch.object(netsnmp, 'VarList')
 class SimpleSessionTest(unittest.TestCase):
 
     def setUp(self):
-        self.var = make_varbind('sysDescr.0', 'Fake system description.')
+        self.var = netsnmp.Varbind('sysDescr.0', val='Fake system description.')
         self.var_list = [
-            make_varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150', '2'),
-            make_varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160', '1'),
+            netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
+                            val='2'),
+            netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
+                            val='1'),
         ]
         self.mock_session = mock.Mock(spec=netsnmp.Session)
         self.mock_session.ErrorStr = None
@@ -35,18 +31,18 @@ class SimpleSessionTest(unittest.TestCase):
 
         actual = self.session.get('sysDescr.0')
 
-        self.assertItemsEqual(
-            [{'tag': 'sysDescr.0',
-              'val': self.var.val}], actual)
+        self.assertEqual(1, len(actual))
+        self.assertEqual('sysDescr.0', actual[0].oid)
+        self.assertEqual(self.var.val, actual[0].value)
         self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
         mock_varbind.assert_called_with('sysDescr.0')
 
     def test_get_returns_empty_list(self, mock_varlist, mock_varbind):
         mock_varlist.return_value = []
 
-        actual = self.session.get('missingMib.0')
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.get('missingMib.0')
 
-        self.assertItemsEqual([], actual)
         self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
         mock_varbind.assert_called_with('missingMib.0')
 
@@ -67,11 +63,13 @@ class SimpleSessionTest(unittest.TestCase):
 
         actual = self.session.walk('BRIDGE-MIB::dot1dTpFdbPort')
 
-        self.assertItemsEqual(
-            [{'tag': 'BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
-              'val': '2'},
-             {'tag': 'BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
-              'val': '1'}], actual)
+        self.assertEqual(2, len(actual))
+        self.assertEqual('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
+                         actual[0].oid)
+        self.assertEqual('2', actual[0].value)
+        self.assertEqual('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
+                         actual[1].oid)
+        self.assertEqual('1', actual[1].value)
         self.mock_session.walk.assert_called_once_with(
             mock_varlist.return_value)
         mock_varbind.assert_called_with('BRIDGE-MIB::dot1dTpFdbPort')
@@ -79,9 +77,9 @@ class SimpleSessionTest(unittest.TestCase):
     def test_walk_returns_empty_list(self, mock_varlist, mock_varbind):
         mock_varlist.return_value = []
 
-        actual = self.session.walk('missingMib.0')
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.walk('missingMib.0')
 
-        self.assertItemsEqual([], actual)
         self.mock_session.walk.assert_called_once_with(
             mock_varlist.return_value)
         mock_varbind.assert_called_with('missingMib.0')
@@ -111,16 +109,16 @@ class FakeSessionTest(unittest.TestCase):
     def test_get(self):
         actual = self.session.get('sysDescr.0')
 
-        self.assertItemsEqual(
-            [{'tag': 'sysDescr.0',
-              'val': 'Fake system description.'}], actual)
+        self.assertEqual(1, len(actual))
+        self.assertEqual('sysDescr.0', actual[0].oid)
+        self.assertEqual('Fake system description.', actual[0].value)
 
     def test_walk(self):
         actual = self.session.walk('sysDescr.0')
 
-        self.assertItemsEqual(
-            [{'tag': 'sysDescr.0',
-              'val': 'Fake system description.'}], actual)
+        self.assertEqual(1, len(actual))
+        self.assertEqual('sysDescr.0', actual[0].oid)
+        self.assertEqual('Fake system description.', actual[0].value)
 
 
 if __name__ == '__main__':

--- a/site-packages/mlab/disco/simple_session_test.py
+++ b/site-packages/mlab/disco/simple_session_test.py
@@ -10,12 +10,10 @@ import mock
 import simple_session
 
 
-class FakeVarbind(object):
-    """A fake netsnmp.Varbind object."""
-
-    def __init__(self, tag, val):
-        self.tag = tag
-        self.val = val
+def make_varbind(tag, val):
+    var = netsnmp.Varbind(tag)
+    var.val = val
+    return var
 
 
 @mock.patch.object(netsnmp, 'Varbind')
@@ -23,8 +21,13 @@ class FakeVarbind(object):
 class SimpleSessionTest(unittest.TestCase):
 
     def setUp(self):
-        self.var = FakeVarbind('sysDescr.0', 'Fake system description.')
+        self.var = make_varbind('sysDescr.0', 'Fake system description.')
+        self.var_list = [
+            make_varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150', '2'),
+            make_varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160', '1'),
+        ]
         self.mock_session = mock.Mock(spec=netsnmp.Session)
+        self.mock_session.ErrorStr = None
         self.session = simple_session.SimpleSession(self.mock_session)
 
     def test_get(self, mock_varlist, mock_varbind):
@@ -38,17 +41,63 @@ class SimpleSessionTest(unittest.TestCase):
         self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
         mock_varbind.assert_called_with('sysDescr.0')
 
-    def test_walk(self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = [self.var]
+    def test_get_returns_empty_list(self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = []
 
-        actual = self.session.walk('sysDescr.0')
+        actual = self.session.get('missingMib.0')
+
+        self.assertItemsEqual([], actual)
+        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
+        mock_varbind.assert_called_with('missingMib.0')
+
+    def test_get_raises_SNMPError_when_ErrorStr_is_not_empty(self, mock_varlist,
+                                                             mock_varbind):
+        mock_varlist.return_value = [self.var]
+        self.mock_session.ErrorStr = 'Timeout'
+        self.mock_session.ErrorInd = -24
+
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.get('fakeMib.0')
+
+        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
+        mock_varbind.assert_called_with('fakeMib.0')
+
+    def test_walk(self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = self.var_list
+
+        actual = self.session.walk('BRIDGE-MIB::dot1dTpFdbPort')
 
         self.assertItemsEqual(
-            [{'tag': 'sysDescr.0',
-              'val': self.var.val}], actual)
+            [{'tag': 'BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
+              'val': '2'},
+             {'tag': 'BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
+              'val': '1'}], actual)
         self.mock_session.walk.assert_called_once_with(
             mock_varlist.return_value)
-        mock_varbind.assert_called_with('sysDescr.0')
+        mock_varbind.assert_called_with('BRIDGE-MIB::dot1dTpFdbPort')
+
+    def test_walk_returns_empty_list(self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = []
+
+        actual = self.session.walk('missingMib.0')
+
+        self.assertItemsEqual([], actual)
+        self.mock_session.walk.assert_called_once_with(
+            mock_varlist.return_value)
+        mock_varbind.assert_called_with('missingMib.0')
+
+    def test_walk_raises_SNMPError_when_ErrorStr_is_not_empty(
+            self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = [self.var]
+        self.mock_session.ErrorStr = 'Timeout'
+        self.mock_session.ErrorInd = -24
+
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.walk('fakeMib.0')
+
+        self.mock_session.walk.assert_called_once_with(
+            mock_varlist.return_value)
+        mock_varbind.assert_called_with('fakeMib.0')
 
 
 class FakeSessionTest(unittest.TestCase):

--- a/site-packages/mlab/disco/simple_session_test.py
+++ b/site-packages/mlab/disco/simple_session_test.py
@@ -1,0 +1,78 @@
+"""Tests for simple_session."""
+
+import netsnmp
+import unittest
+
+# Third-party modules.
+import mock
+
+# Module under test.
+import simple_session
+
+
+class FakeVarbind(object):
+    """A fake netsnmp.Varbind object."""
+
+    def __init__(self, tag, val):
+        self.tag = tag
+        self.val = val
+
+
+@mock.patch.object(netsnmp, 'Varbind')
+@mock.patch.object(netsnmp, 'VarList')
+class SimpleSessionTest(unittest.TestCase):
+
+    def setUp(self):
+        self.var = FakeVarbind('sysDescr.0', 'Fake system description.')
+        self.mock_session = mock.Mock(spec=netsnmp.Session)
+        self.session = simple_session.SimpleSession(self.mock_session)
+
+    def test_get(self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = [self.var]
+
+        actual = self.session.get('sysDescr.0')
+
+        self.assertItemsEqual(
+            [{'tag': 'sysDescr.0',
+              'val': self.var.val}], actual)
+        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
+        mock_varbind.assert_called_with('sysDescr.0')
+
+    def test_walk(self, mock_varlist, mock_varbind):
+        mock_varlist.return_value = [self.var]
+
+        actual = self.session.walk('sysDescr.0')
+
+        self.assertItemsEqual(
+            [{'tag': 'sysDescr.0',
+              'val': self.var.val}], actual)
+        self.mock_session.walk.assert_called_once_with(
+            mock_varlist.return_value)
+        mock_varbind.assert_called_with('sysDescr.0')
+
+
+class FakeSessionTest(unittest.TestCase):
+    """Tests for the simple_session.FakeSession class."""
+
+    def setUp(self):
+        self.session = simple_session.FakeSession()
+        self.session.prepare('sysDescr.0', 'sysDescr.0',
+                             'Fake system description.')
+
+    def test_get(self):
+        actual = self.session.get('sysDescr.0')
+
+        self.assertItemsEqual(
+            [{'tag': 'sysDescr.0',
+              'val': 'Fake system description.'}], actual)
+
+    def test_walk(self):
+        actual = self.session.walk('sysDescr.0')
+
+        self.assertItemsEqual(
+            [{'tag': 'sysDescr.0',
+              'val': 'Fake system description.'}], actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/site-packages/mlab/disco/simple_session_test.py
+++ b/site-packages/mlab/disco/simple_session_test.py
@@ -10,56 +10,58 @@ import mock
 import simple_session
 
 
-@mock.patch.object(netsnmp, 'Varbind')
-@mock.patch.object(netsnmp, 'VarList')
 class SimpleSessionTest(unittest.TestCase):
 
     def setUp(self):
-        self.var = netsnmp.Varbind('sysDescr.0', val='Fake system description.')
-        self.var_list = [
-            netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
-                            val='2'),
-            netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
-                            val='1'),
-        ]
         self.mock_session = mock.Mock(spec=netsnmp.Session)
         self.mock_session.ErrorStr = None
         self.session = simple_session.SimpleSession(self.mock_session)
 
-    def test_get(self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = [self.var]
+    def test_get(self):
+
+        def fake_get(varlist):
+            """Replaces netsnmp.Session.get to set varbind value."""
+            varlist[0].val = 'fake sysdescr'
+
+        self.mock_session.get.side_effect = fake_get
 
         actual = self.session.get('sysDescr.0')
 
         self.assertEqual(1, len(actual))
         self.assertEqual('sysDescr.0', actual[0].oid)
-        self.assertEqual(self.var.val, actual[0].value)
-        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
-        mock_varbind.assert_called_with('sysDescr.0')
+        self.assertEqual('fake sysdescr', actual[0].value)
 
-    def test_get_returns_empty_list(self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = []
+    def test_get_raises_SNMPError_when_varlist_has_no_values(self):
+
+        def fake_get(varlist):
+            """Replaces netsnmp.Session.get to set varbind value."""
+            varlist[0].val = None
+
+        self.mock_session.get.side_effect = fake_get
 
         with self.assertRaises(simple_session.SNMPError):
             self.session.get('missingMib.0')
 
-        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
-        mock_varbind.assert_called_with('missingMib.0')
-
-    def test_get_raises_SNMPError_when_ErrorStr_is_not_empty(self, mock_varlist,
-                                                             mock_varbind):
-        mock_varlist.return_value = [self.var]
+    def test_get_raises_SNMPError_when_ErrorStr_is_not_empty(self):
         self.mock_session.ErrorStr = 'Timeout'
         self.mock_session.ErrorInd = -24
 
         with self.assertRaises(simple_session.SNMPError):
             self.session.get('fakeMib.0')
 
-        self.mock_session.get.assert_called_once_with(mock_varlist.return_value)
-        mock_varbind.assert_called_with('fakeMib.0')
+    def test_walk(self):
 
-    def test_walk(self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = self.var_list
+        def fake_walk(varlist):
+            """Replaces netsnmp.Session.walk to add new varbind values."""
+            del varlist[0]
+            varlist.append(
+                netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.150',
+                                val='2'))
+            varlist.append(
+                netsnmp.Varbind('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
+                                val='1'))
+
+        self.mock_session.walk.side_effect = fake_walk
 
         actual = self.session.walk('BRIDGE-MIB::dot1dTpFdbPort')
 
@@ -70,32 +72,24 @@ class SimpleSessionTest(unittest.TestCase):
         self.assertEqual('BRIDGE-MIB::dot1dTpFdbPort.0.12.34.56.78.160',
                          actual[1].oid)
         self.assertEqual('1', actual[1].value)
-        self.mock_session.walk.assert_called_once_with(
-            mock_varlist.return_value)
-        mock_varbind.assert_called_with('BRIDGE-MIB::dot1dTpFdbPort')
 
-    def test_walk_returns_empty_list(self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = []
+    def test_walk_raises_SNMPError_when_varlist_has_no_values(self):
+
+        def fake_walk(varlist):
+            """Replaces netsnmp.Session.get to set varbind value."""
+            varlist[0].val = None
+
+        self.mock_session.walk.side_effect = fake_walk
 
         with self.assertRaises(simple_session.SNMPError):
-            self.session.walk('missingMib.0')
+            self.session.get('missingMib.0')
 
-        self.mock_session.walk.assert_called_once_with(
-            mock_varlist.return_value)
-        mock_varbind.assert_called_with('missingMib.0')
-
-    def test_walk_raises_SNMPError_when_ErrorStr_is_not_empty(
-            self, mock_varlist, mock_varbind):
-        mock_varlist.return_value = [self.var]
+    def test_walk_raises_SNMPError_when_ErrorStr_is_not_empty(self):
         self.mock_session.ErrorStr = 'Timeout'
         self.mock_session.ErrorInd = -24
 
         with self.assertRaises(simple_session.SNMPError):
             self.session.walk('fakeMib.0')
-
-        self.mock_session.walk.assert_called_once_with(
-            mock_varlist.return_value)
-        mock_varbind.assert_called_with('fakeMib.0')
 
 
 class FakeSessionTest(unittest.TestCase):


### PR DESCRIPTION
This change adds a simple session class that simplifies the interface to netsnmp.Session. As well, this change adds a fake session class for use in tests in other modules that take a session object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/36)
<!-- Reviewable:end -->
