### PR TITLE
Also raise exceptions from FakeSession.

### DIFF
--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -100,7 +100,7 @@ class FakeSession(object):
     def _find_oid(self, oid):
         result = self._mib[oid]
         if not result:
-            raise SNMPError('netsnmp error unknown; OID may be invalid: ' + oid)
+            raise SNMPError('Empty result set.')
         return result
 
 
@@ -118,7 +118,20 @@ def _varlist_to_list(varlist):
 
 
 def _convert_result(original_oid, varlist):
-    """Converts results in varlist, or raises exceptions for errors."""
+    """Converts a netsnmp.Varlist to a list of SNMPVariable.
+
+    Args:
+        original_oid: str, the original OID requested.
+        varlist: netsnmp.VarList, a container filled with netsnmp.Varbind
+            objects.
+
+    Returns:
+        list of SNMPVariable, each netsnmp.Varbind element from varlist
+            converted to an SNMPVariable.
+
+    Raises:
+        SNMPError: after conversion, the result was an empty set.
+    """
     result = _varlist_to_list(varlist)
     if not result:
         raise SNMPError('netsnmp error unknown; OID may be invalid: ' +

--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -92,10 +92,16 @@ class FakeSession(object):
         self._mib[oid].append(SNMPVariable(tag, value))
 
     def get(self, oid):
-        return _convert_result(oid, self._mib[oid], convert=lambda x: x)
+        return self._find_oid(oid)
 
     def walk(self, oid):
-        return _convert_result(oid, self._mib[oid], convert=lambda x: x)
+        return self._find_oid(oid)
+
+    def _find_oid(self, oid):
+        result = self._mib[oid]
+        if not result:
+            raise SNMPError('netsnmp error unknown; OID may be invalid: ' + oid)
+        return result
 
 
 def _varlist_to_list(varlist):
@@ -111,9 +117,9 @@ def _varlist_to_list(varlist):
     return result
 
 
-def _convert_result(original_oid, varlist, convert=_varlist_to_list):
+def _convert_result(original_oid, varlist):
     """Converts results in varlist, or raises exceptions for errors."""
-    result = convert(varlist)
+    result = _varlist_to_list(varlist)
     if not result:
         raise SNMPError('netsnmp error unknown; OID may be invalid: ' +
                         original_oid)

--- a/site-packages/mlab/disco/simple_session.py
+++ b/site-packages/mlab/disco/simple_session.py
@@ -54,7 +54,8 @@ class SimpleSession(object):
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.get(oids)
-        return self._handle_result(oid, oids)
+        self._check_errorstr()
+        return _convert_result(oid, oids)
 
     def walk(self, oid):
         """Reads all values in the MIB tree starting at the given OID.
@@ -70,29 +71,14 @@ class SimpleSession(object):
         """
         oids = netsnmp.VarList(netsnmp.Varbind(oid))
         self._session.walk(oids)
-        return self._handle_result(oid, oids)
+        self._check_errorstr()
+        return _convert_result(oid, oids)
 
-    def _handle_result(self, oid, oids):
-        """Converts results in oids, or raises exceptions for errors."""
+    def _check_errorstr(self):
+        """Raises an exception if the session ErrorStr attribute is set."""
         if self._session.ErrorStr:
             raise SNMPError('netsnmp error; %s: %s' % (self._session.ErrorStr,
                                                        self._session.ErrorInd))
-        result = self._varlist_to_list(oids)
-        if not result:
-            raise SNMPError('netsnmp error unknown; OID may be invalid: ' + oid)
-        return result
-
-    def _varlist_to_list(self, oids):
-        """Converts a netsnmp.Varlist to a list of SNMPVariable."""
-        # The oid.val attribute starts as None and is set after a successful
-        # request. If it is still None, then the request failed and it should
-        # be excluded from the return value.
-        result = []
-        for oid in oids:
-            if oid.val is not None:
-                tag = oid.tag + ('.' + oid.iid if oid.iid else '')
-                result.append(SNMPVariable(tag, oid.val))
-        return result
 
 
 class FakeSession(object):
@@ -106,7 +92,29 @@ class FakeSession(object):
         self._mib[oid].append(SNMPVariable(tag, value))
 
     def get(self, oid):
-        return self._mib[oid]
+        return _convert_result(oid, self._mib[oid], convert=lambda x: x)
 
     def walk(self, oid):
-        return self._mib[oid]
+        return _convert_result(oid, self._mib[oid], convert=lambda x: x)
+
+
+def _varlist_to_list(varlist):
+    """Converts a netsnmp.Varlist to a list of SNMPVariable."""
+    # The oid.val attribute starts as None and is set after a successful
+    # request. If it is still None, then the request failed and it should
+    # be excluded from the return value.
+    result = []
+    for oid in varlist:
+        if oid.val is not None:
+            tag = oid.tag + ('.' + oid.iid if oid.iid else '')
+            result.append(SNMPVariable(tag, oid.val))
+    return result
+
+
+def _convert_result(original_oid, varlist, convert=_varlist_to_list):
+    """Converts results in varlist, or raises exceptions for errors."""
+    result = convert(varlist)
+    if not result:
+        raise SNMPError('netsnmp error unknown; OID may be invalid: ' +
+                        original_oid)
+    return result

--- a/site-packages/mlab/disco/simple_session_test.py
+++ b/site-packages/mlab/disco/simple_session_test.py
@@ -97,22 +97,37 @@ class FakeSessionTest(unittest.TestCase):
 
     def setUp(self):
         self.session = simple_session.FakeSession()
+
+    def test_get(self):
         self.session.prepare('sysDescr.0', 'sysDescr.0',
                              'Fake system description.')
 
-    def test_get(self):
         actual = self.session.get('sysDescr.0')
 
         self.assertEqual(1, len(actual))
         self.assertEqual('sysDescr.0', actual[0].oid)
         self.assertEqual('Fake system description.', actual[0].value)
 
-    def test_walk(self):
-        actual = self.session.walk('sysDescr.0')
+    def test_get_raises_SNMPError_when_results_are_empty(self):
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.get('sysDescr.0')
 
-        self.assertEqual(1, len(actual))
-        self.assertEqual('sysDescr.0', actual[0].oid)
-        self.assertEqual('Fake system description.', actual[0].value)
+    def test_walk(self):
+        # Two results for the same OID.
+        self.session.prepare('a.0', 'a.0.1', 'value1')
+        self.session.prepare('a.0', 'a.0.2', 'value2')
+
+        actual = self.session.walk('a.0')
+
+        self.assertEqual(2, len(actual))
+        self.assertEqual('a.0.1', actual[0].oid)
+        self.assertEqual('value1', actual[0].value)
+        self.assertEqual('a.0.2', actual[1].oid)
+        self.assertEqual('value2', actual[1].value)
+
+    def test_walk_raises_SNMPError_when_results_are_empty(self):
+        with self.assertRaises(simple_session.SNMPError):
+            self.session.get('a.0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`SimpleSession.get` and `walk` now raise exceptions when no results were returned. So, `FakeSession` should behave the same way.

This PR rearranges some previously private functions to be used by both `SimpleSession` and `FakeSession`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/42)
<!-- Reviewable:end -->
