### PR TITLE
Create a run_export.sh script for all export handling.

### DIFF
--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -63,31 +63,31 @@ plugin, and processes for periodic data export.
 #
 
 # Overview and license.
-install -D -m 644 README.md	%{buildroot}/usr/share/collectd-mlab/README.md
-install -D -m 644 LICENSE	%{buildroot}/usr/share/collectd-mlab/LICENSE
+install -D -m 644 README.md %{buildroot}/usr/share/collectd-mlab/README.md
+install -D -m 644 LICENSE   %{buildroot}/usr/share/collectd-mlab/LICENSE
 
 # Data export scripts.
-install -D -m 755 export/mlab_export_cleanup.cron	%{buildroot}/etc/cron.daily/mlab_export_cleanup.cron
-install -D -m 644 export/mlab_export.cron		%{buildroot}/etc/cron.d/mlab_export.cron
-install -D -m 755 export/mlab_export.py			%{buildroot}/usr/bin/mlab_export.py
-install -D -m 644 export/export_metrics.conf		%{buildroot}/usr/share/collectd-mlab/export_metrics.conf
-install -D -m 644 export/mlab_collectd_watchdog.cron	%{buildroot}/etc/cron.d/mlab_collectd_watchdog.cron
-install -D -m 755 export/mlab_collectd_watchdog.sh		%{buildroot}/usr/share/collectd-mlab/mlab_collectd_watchdog.sh
-install -D -m 755 export/run_export.sh			%{buildroot}/usr/share/collectd-mlab/run_export.sh
+install -D -m 755 export/mlab_export_cleanup.cron    %{buildroot}/etc/cron.daily/mlab_export_cleanup.cron
+install -D -m 644 export/mlab_export.cron            %{buildroot}/etc/cron.d/mlab_export.cron
+install -D -m 755 export/mlab_export.py              %{buildroot}/usr/bin/mlab_export.py
+install -D -m 644 export/export_metrics.conf         %{buildroot}/usr/share/collectd-mlab/export_metrics.conf
+install -D -m 644 export/mlab_collectd_watchdog.cron %{buildroot}/etc/cron.d/mlab_collectd_watchdog.cron
+install -D -m 755 export/mlab_collectd_watchdog.sh   %{buildroot}/usr/share/collectd-mlab/mlab_collectd_watchdog.sh
+install -D -m 755 export/run_export.sh               %{buildroot}/usr/share/collectd-mlab/run_export.sh
 
 # Configuration for *limited* access to collectd-web.
-install -D -m 755 viewer/mlab-view 			%{buildroot}/usr/bin/mlab-view
-install -D -m 644 viewer/httpd.collectd.conf		%{buildroot}/usr/share/collectd-mlab/httpd.conf
-install -D -m 644 viewer/collection-mlab.conf		%{buildroot}/etc/collection-mlab.conf
+install -D -m 755 viewer/mlab-view            %{buildroot}/usr/bin/mlab-view
+install -D -m 644 viewer/httpd.collectd.conf  %{buildroot}/usr/share/collectd-mlab/httpd.conf
+install -D -m 644 viewer/collection-mlab.conf %{buildroot}/etc/collection-mlab.conf
 
 # Collectd configuration.
-install -D -m 644 plugin/collectd			%{buildroot}/etc/default/collectd
-install -D -m 644 plugin/collectd-mlab.conf		%{buildroot}/etc/collectd-mlab.conf
-install -D -m 644 plugin/types.db			%{buildroot}/usr/share/collectd-mlab/types.db
-install -D -m 644 plugin/mlab.py			%{buildroot}/var/lib/collectd/python/mlab_vs.py
+install -D -m 644 plugin/collectd           %{buildroot}/etc/default/collectd
+install -D -m 644 plugin/collectd-mlab.conf %{buildroot}/etc/collectd-mlab.conf
+install -D -m 644 plugin/types.db           %{buildroot}/usr/share/collectd-mlab/types.db
+install -D -m 644 plugin/mlab.py            %{buildroot}/var/lib/collectd/python/mlab_vs.py
 
 # Init script.
-install -D -m 755 plugin/collectd-setup		%{buildroot}/etc/init.d/collectd-setup
+install -D -m 755 plugin/collectd-setup     %{buildroot}/etc/init.d/collectd-setup
 
 # Python site-packages modules.
 install -d %{buildroot}/%{site_packages}/mlab/disco
@@ -102,7 +102,7 @@ install -D -m 644 site-packages/mlab/disco/__init__.py \
                   %{buildroot}/%{site_packages}/mlab/disco
 
 # Disco commands.
-install -D -m 755 disco/disco_config.py	%{buildroot}/usr/bin/disco_config.py
+install -D -m 755 disco/disco_config.py     %{buildroot}/usr/bin/disco_config.py
 
 # Disco config.
 install -D -m 644 disco/models.yaml \

--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -183,10 +183,6 @@ chkconfig rsyslog on
 chkconfig collectd on
 chkconfig collectd-setup on
 
-# TODO(soltesz): fix mlab_export.py to handle initial conditions correctly.
-# Initialize the lastexport timestamp file to one hour ago.
-touch -t $( date +%Y%m%d%H00 -d "-1 hour" ) /var/lib/collectd/lastexport.tstamp
-
 # TODO(soltesz): what package should own this file?
 touch %{site_packages}/mlab/__init__.py
 

--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -73,6 +73,7 @@ install -D -m 755 export/mlab_export.py			%{buildroot}/usr/bin/mlab_export.py
 install -D -m 644 export/export_metrics.conf		%{buildroot}/usr/share/collectd-mlab/export_metrics.conf
 install -D -m 644 export/mlab_collectd_watchdog.cron	%{buildroot}/etc/cron.d/mlab_collectd_watchdog.cron
 install -D -m 755 export/mlab_collectd_watchdog.sh		%{buildroot}/usr/share/collectd-mlab/mlab_collectd_watchdog.sh
+install -D -m 755 export/run_export.sh			%{buildroot}/usr/share/collectd-mlab/run_export.sh
 
 # Configuration for *limited* access to collectd-web.
 install -D -m 755 viewer/mlab-view 			%{buildroot}/usr/bin/mlab-view
@@ -132,6 +133,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/mlab_export.py
 /usr/share/collectd-mlab/export_metrics.conf
 /usr/share/collectd-mlab/mlab_collectd_watchdog.sh
+/usr/share/collectd-mlab/run_export.sh
 /etc/cron.d/mlab_export.cron
 /etc/cron.d/mlab_collectd_watchdog.cron
 /etc/cron.daily/mlab_export_cleanup.cron

--- a/export/mlab_export.cron
+++ b/export/mlab_export.cron
@@ -27,5 +27,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
 #
 # Thus, the cron start matches --ts_offset.
 #
-10 * * * * root	 /usr/bin/mlab_export.py --noupdate --compress > /dev/null
-11 * * * * root	 /usr/bin/mlab_export.py --suffix=switch --compress > /dev/null
+10 * * * * root	 /usr/share/collectd-mlab/run_export.sh

--- a/export/run_export.sh
+++ b/export/run_export.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if test -s /home/mlab_utility/conf/snmp.community ; then
+    /usr/bin/mlab_export.py --noupdate --suffix=switch --compress > /dev/null
+fi
+/usr/bin/mlab_export.py --compress > /dev/null

--- a/export/run_export.sh
+++ b/export/run_export.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 if test -s /home/mlab_utility/conf/snmp.community ; then
+    if ! test -f /var/lib/collectd/lastexport.tstamp ; then
+        # TODO(soltesz): Fix mlab_export.py to handle initial conditions
+        # correctly. Initialize the lastexport timestamp file to one hour ago
+        # for first export.
+        touch -t $( date +%Y%m%d%H00 -d "-1 hour" ) /var/lib/collectd/lastexport.tstamp
+    fi
     /usr/bin/mlab_export.py --noupdate --suffix=switch --compress > /dev/null
 fi
 /usr/bin/mlab_export.py --compress > /dev/null


### PR DESCRIPTION
This PR moves the direct calls to `mlab_export.sh` from `mlab_export.cron` to a new shell script, `run_export.sh`.

The shell script will conditionally run the switch data export and correctly (temporarily) handle a missing `lastexport.tstamp` which `mlab_export.py` does not handle correctly yet when `--noupdate` is given.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/48)
<!-- Reviewable:end -->
