### PR TITLE
Restore: Fix out-of-sync lastexport time stamp.

### DIFF
--- a/export/mlab_export.py
+++ b/export/mlab_export.py
@@ -604,8 +604,8 @@ def init_args(options, ts_previous):
         options.ts_start = default_start_time(options, ts_previous)
 
     if options.ts_end is None:
-        options.ts_end = (
-            align_timestamp(options.ts_start, options.step) + options.length)
+        options.ts_end = default_end_time(options.length)
+        options.length = options.ts_end - options.ts_start
 
     if any_show_options(options):
         options.update = False

--- a/export/mlab_export_test.py
+++ b/export/mlab_export_test.py
@@ -16,6 +16,7 @@
 import logging
 import os
 import StringIO
+import time
 import unittest
 
 # Third-party modules.
@@ -127,6 +128,14 @@ class MlabExport_GlobalTests(unittest.TestCase):
                                                         ts_previous)
 
         self.assertEqual(returned_start, expected_start)
+
+    @mock.patch.object(time, 'time')
+    def testunit_default_end_time(self, mock_time):
+        mock_time.return_value = FAKE_TIMESTAMP
+
+        actual_end = mlab_export.default_end_time(1000)
+
+        self.assertEqual(actual_end, FAKE_TIMESTAMP)
 
     @mock.patch('mlab_export.time.time')
     def testunit_default_start_time_WHEN_ts_previous_IS_zero(self, mock_time):
@@ -373,10 +382,11 @@ class MlabExport_GlobalTests(unittest.TestCase):
             mlab_export.read_metric_map(fake_metric_conf, 'metrics')
 
     @mock.patch('mlab_export.default_output_name')
+    @mock.patch('mlab_export.default_end_time')
     @mock.patch('mlab_export.default_start_time')
     @mock.patch('mlab_export.read_metric_map')
     def testunit_init_args(self, mock_read_metric_map, mock_default_start_time,
-                           mock_default_output_name):
+                           mock_default_end_time, mock_default_output_name):
         mock_options = disable_show_options(mock.Mock())
         mock_options.rrddir_prefix = os.path.join(self._testdata_dir, 'rrd')
         mock_options.exclude = []
@@ -394,6 +404,7 @@ class MlabExport_GlobalTests(unittest.TestCase):
         mlab_export.HOSTNAME = 'mlab2.nuq0t'
         mock_default_output_name.return_value = 'fake-output-name'
         mock_default_start_time.return_value = FAKE_TIMESTAMP
+        mock_default_end_time.return_value = FAKE_TIMESTAMP + 1000
         ts_previous = 0
 
         mlab_export.init_args(mock_options, ts_previous)


### PR DESCRIPTION
PR #26 was reverted accidentally by PR #27.  This change restores the fix for out-of-sync lastexport timestamps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/50)
<!-- Reviewable:end -->
