### PR TITLE
Add option to export counts rather than rates.

### DIFF
--- a/export/mlab_export_test.py
+++ b/export/mlab_export_test.py
@@ -257,7 +257,24 @@ class MlabExport_GlobalTests(unittest.TestCase):
 
         returned_value = mlab_export.get_json_record(
             'mlab2.nuq0t', 'utility.mlab', 'network.ipv4.bytes.rx', timestamps,
-            values)
+            values, 1)
+
+        self.assertEqual(returned_value, expected_value)
+
+    def testunit_get_json_record_when_scale_is_10(self):
+        timestamps = [1, 2, 3]
+        values = [10.0, 11.0, 12.0]
+        expected_value = {'sample': [
+                             {'timestamp': 1, 'value': 100.0},
+                             {'timestamp': 2, 'value': 110.0},
+                             {'timestamp': 3, 'value': 120.0}],
+                          'metric': 'network.ipv4.bytes.rx',
+                          'hostname': 'mlab2.nuq0t',
+                          'experiment': 'utility.mlab'}  # yapf: disable
+
+        returned_value = mlab_export.get_json_record(
+            'mlab2.nuq0t', 'utility.mlab', 'network.ipv4.bytes.rx', timestamps,
+            values, 10)
 
         self.assertEqual(returned_value, expected_value)
 
@@ -332,6 +349,7 @@ class MlabExport_GlobalTests(unittest.TestCase):
         mock_options.output = 'output'
         mock_options.ts_start = 0
         mock_options.ts_end = 10
+        mock_options.counts = False
         expected_value = (
             '{"sample": [{"timestamp": 0, "value": 0.0}], '
             '"metric": "fake_metric_name", "hostname": "fake_hostname", '

--- a/export/run_export.sh
+++ b/export/run_export.sh
@@ -7,6 +7,6 @@ if test -s /home/mlab_utility/conf/snmp.community ; then
         # for first export.
         touch -t $( date +%Y%m%d%H00 -d "-1 hour" ) /var/lib/collectd/lastexport.tstamp
     fi
-    /usr/bin/mlab_export.py --noupdate --suffix=switch --compress > /dev/null
+    /usr/bin/mlab_export.py --noupdate --suffix=switch --counts --compress > /dev/null
 fi
 /usr/bin/mlab_export.py --compress > /dev/null


### PR DESCRIPTION
This PR adds a new boolean flag to `mlab_export.py [--counts]` that exports metric counts rather than rates. The default is False, which preserves current behavior.

This feature is needed to export raw counts for the switch traffic data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/52)
<!-- Reviewable:end -->
