### PR TITLE
Disco logging and debugging auto-discovery doc

### DIFF
--- a/DEBUG.md
+++ b/DEBUG.md
@@ -36,7 +36,8 @@ disco_config.py --command update-snmp-community \
 The output from this command should be saved to
 `/home/mlab_utility/conf/snmp.community.updated`. If the output does not match
 the content of this file (or, the file is empty) there may be an error
-discovering VLANs.
+discovering VLANs. See the Cisco notes below for Cisco switches. For other
+switch types, see the command for querying `sysDescr.0` below.
 
 ## QFX and HP Procurve
 
@@ -121,7 +122,9 @@ $ snmpwalk -v 2c -c $COMM $SWITCH .1.3.6.1.2.1.17.7.1.4.3.1.1
 
 Cisco switches segregate SNMP data per VLAN. SNMP data for each vlan is
 accessed via a modified SNMP community string. The SNMP community string is
-modified by appending `@<vlanid>` to the end.
+modified by appending `@<vlanid>` to the end. For example, if the community
+string is "banana" and the VLAN id is 102, then the modified community string
+would be "banana@102"
 
 So, Disco must first discover which VLAN contains the M-Lab servers. Disco does
 this using the CISCO-VTP-MIB vtpVlanIfIndex (.1.3.6.1.4.1.9.9.46.1.3.1.1.18) to
@@ -138,10 +141,10 @@ echo `cat /home/mlab_utility/conf/snmp.community`@$VLANID \
     > /home/mlab_utility/conf/snmp.community.updated
 ```
 
-Ignore VLANs with id zero (0). VLAN 1 is the default VLAN. All others are
-candidates. The above command assumes there is only *one* other VLAN, so it may
-fail for systems with multiple. Disco should handle multiple VLANs
-automatically.
+Disco handles multiple VLANs automatically. The above command does not because
+it assumes there is only *one* additional VLAN. The command above ignores VLANs
+with id zero (0) and VLAN one (1). VLAN 1 is the default VLAN. All other
+non-0 and non-1 VLANs are candidates.
 
 As for other switches, we lookup the MAC addresses learned on each port. Though
 for Cisco switches, we must use the BRIDGE-MIB::dot1dTpFdbPort OID.

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,13 +1,27 @@
 # Debugging Disco Auto-discovery
 
-## QFX and HP Proliant
+Login to the `mlab_utility` slice at the site of your choice and setup some
+convenience variables.
 
-Login to the `mlab_utility` slice at the site of your choice.
 ```
 ssh mlab_utility@mlab1.{site}.measurement-lab.org
 COMM=`cat /home/mlab_utility/conf/snmp.community.updated`
 SWITCH="s1.${HOSTNAME#*.}"
 ```
+
+## Running Disco config
+
+The `disco_config.py` command line tool should generate the contents for
+`/etc/collectd-snmp.conf`. Normally this is done every time `service collectd
+start` or `service collectd restart`, but the error output may be hidden.
+
+```
+disco_config.py --command collectd-snmp-config \
+    --community_file=/home/mlab_utility/conf/snmp.community \
+	--hostname $SWITCH
+```
+
+## QFX and HP Proliant
 
 Learn the switch model.
 ```

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -36,8 +36,9 @@ disco_config.py --command update-snmp-community \
 The output from this command should be saved to
 `/home/mlab_utility/conf/snmp.community.updated`. If the output does not match
 the content of this file (or, the file is empty) there may be an error
-discovering VLANs. See the Cisco notes below for Cisco switches. For other
-switch types, see the command for querying `sysDescr.0` below.
+discovering VLANs. To diagnose Cisco switches, see the Cisco notes below. To
+diagnose other switch types, start with the commands for querying `sysDescr.0`
+below.
 
 ## QFX and HP Procurve
 

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -1,0 +1,88 @@
+# Debugging Disco Auto-discovery
+
+## QFX and HP Proliant
+
+Login to the `mlab_utility` slice at the site of your choice.
+```
+ssh mlab_utility@mlab1.{site}.measurement-lab.org
+COMM=`cat /home/mlab_utility/conf/snmp.community.updated`
+SWITCH="s1.${HOSTNAME#*.}"
+```
+
+Learn the switch model.
+```
+$ snmpget -v 2c -c $COMM $SWITCH sysDescr.0
+SNMPv2-MIB::sysDescr.0 = STRING: Juniper Networks, Inc. qfx5100-48s-6q Ethernet Switch, kernel JUNOS 14.1X53-D35.3, Build date: 2016-02-29 23:39:06 UTC Copyright (c) 1996-2016 Juniper Networks, Inc.
+```
+
+Lookup the local machine MAC and uplink MAC addresses using `ifconfig` and
+`arp`. For example:
+
+```
+$ ifconfig eth0 | grep HWaddr
+eth0      Link encap:Ethernet  HWaddr F4:52:14:13:33:F0
+
+$ arp
+Address                  HWtype  HWaddress           Flags Mask            Iface
+165.117.240.1            ether   00:12:c0:88:05:01   C                     eth0
+```
+
+Lookup the MAC addresses learned on each port using the
+"Q-BRIDGE-MIB::dot1qTpFdbPort" OID. Be aware that MAC addresses are represented
+in "dotted decimal" form in SNMP rather than the more common "colon
+hexadecimal" form. The MAC is the last six digits of the returned OIDs. The
+port number is the value on the right hand side.
+
+```
+$ snmpwalk -v 2c -c $COMM $SWITCH .1.3.6.1.2.1.17.7.1.2.2.1.2
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.0.18.192.136.5.1 = INTEGER: 1010
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.228.29.45.23.231.128 = INTEGER: 1083
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.82.20.19.51.16 = INTEGER: 1059
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.82.20.19.51.48 = INTEGER: 1035
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.82.20.19.51.240 = INTEGER: 1011
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.142.56.205.83.200 = INTEGER: 1084
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.142.56.205.84.68 = INTEGER: 1060
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.142.56.205.84.72 = INTEGER: 1036
+SNMPv2-SMI::mib-2.17.7.1.2.2.1.2.196608.244.142.56.205.84.80 = INTEGER: 1012
+```
+
+Lookup the ifIndex for the uplink and local ports using the port values above
+for the corresponding MAC address. Append the port value to the end of the
+"BRIDGE-MIB::dot1dBasePortIfIndex" OID.
+
+```
+$ snmpget -v 2c -c $COMM $SWITCH BRIDGE-MIB::dot1dBasePortIfIndex.1010
+BRIDGE-MIB::dot1dBasePortIfIndex.1010 = INTEGER: 517
+
+$ snmpget -v 2c -c $COMM $SWITCH BRIDGE-MIB::dot1dBasePortIfIndex.1011
+BRIDGE-MIB::dot1dBasePortIfIndex.1011 = INTEGER: 512
+```
+
+If the lookup fails, you may get an error like:
+```
+$ snmpget -v 2c -c $COMM $SWITCH BRIDGE-MIB::dot1dBasePortIfIndex.1018
+BRIDGE-MIB::dot1dBasePortIfIndex.1018 = No Such Instance currently exists at this OID
+```
+
+If the above fails, try walking all values at "BRIDGE-MIB::dot1dBasePortIfIndex".
+Some ports may be missing.
+
+```
+$ snmpwalk -v 2c -c $COMM $SWITCH BRIDGE-MIB::dot1dBasePortIfIndex
+BRIDGE-MIB::dot1dBasePortIfIndex.1010 = INTEGER: 517
+BRIDGE-MIB::dot1dBasePortIfIndex.1011 = INTEGER: 512
+BRIDGE-MIB::dot1dBasePortIfIndex.1012 = INTEGER: 519
+BRIDGE-MIB::dot1dBasePortIfIndex.1035 = INTEGER: 513
+BRIDGE-MIB::dot1dBasePortIfIndex.1036 = INTEGER: 520
+BRIDGE-MIB::dot1dBasePortIfIndex.1059 = INTEGER: 515
+BRIDGE-MIB::dot1dBasePortIfIndex.1060 = INTEGER: 521
+BRIDGE-MIB::dot1dBasePortIfIndex.1083 = INTEGER: 516
+BRIDGE-MIB::dot1dBasePortIfIndex.1084 = INTEGER: 523
+```
+
+The VLANs are configured according to "dot1qVlanStaticName"
+```
+$ snmpwalk -v 2c -c $COMM $SWITCH .1.3.6.1.2.1.17.7.1.4.3.1.1
+```
+
+## Cisco

--- a/DEBUG.md
+++ b/DEBUG.md
@@ -21,7 +21,7 @@ disco_config.py --command collectd-snmp-config \
 	--hostname $SWITCH
 ```
 
-## QFX and HP Proliant
+## QFX and HP Procurve
 
 Learn the switch model.
 ```
@@ -33,12 +33,13 @@ Lookup the local machine MAC and uplink MAC addresses using `ifconfig` and
 `arp`. For example:
 
 ```
-$ ifconfig eth0 | grep HWaddr
-eth0      Link encap:Ethernet  HWaddr F4:52:14:13:33:F0
+$ ip link show eth0
+2: eth0: <BROADCAST,MULTICAST,PROMISC,UP,LOWER_UP> mtu 1500 qdisc mq state UP qlen 1000
+    link/ether f4:52:14:13:33:f0 brd ff:ff:ff:ff:ff:ff
 
-$ arp
-Address                  HWtype  HWaddress           Flags Mask            Iface
-165.117.240.1            ether   00:12:c0:88:05:01   C                     eth0
+$ ip neighbor
+...
+165.117.240.1 dev eth0 lladdr 00:12:c0:88:05:01 DELAY
 ```
 
 Lookup the MAC addresses learned on each port using the

--- a/collectd-mlab.spec
+++ b/collectd-mlab.spec
@@ -4,7 +4,7 @@
 %define name collectd-mlab
 %define slicename mlab_utility
 %define version 2.0
-%define taglevel 1
+%define taglevel 2
 %define releasetag %{taglevel}%{?date:.%{date}}
 
 # NOTE: Disable the brp-python-bytecompile script (which creates *.pyc, *.pyo).
@@ -44,6 +44,8 @@ Requires: python-gflags
 Requires: python-netifaces
 Requires: net-snmp-python
 Requires: PyYAML
+# Extremely convenient for diagnostics.
+Requires: net-snmp-utils
 
 Source0: %{name}-%{version}.tar.bz2
 

--- a/plugin/collectd
+++ b/plugin/collectd
@@ -17,8 +17,8 @@ fi
 # M-Lab specific configuration. So, content in "/etc/collectd.conf" is ignored.
 CONFIG=/etc/collectd-mlab.conf
 
-# NOTE: Run setup before starting.
-if [[ "$1" == "start" ]] ; then
+# NOTE: Run setup before starting or restarting.
+if [[ "$1" == *"start" ]] ; then
     /usr/bin/collectd_snmp_setup.sh
 fi
 

--- a/site-packages/mlab/disco/discovery.py
+++ b/site-packages/mlab/disco/discovery.py
@@ -105,13 +105,11 @@ class DiscoverySession(object):
         macs = {}
         local_mac = network.get_local_mac()
         macs['local'] = _mac_to_oid(local_mac)
-        logging.info('Local MAC: %s as OID: %s', local_mac,
-                     _mac_to_oid(local_mac))
+        logging.info('Local MAC: %s as OID: %s', local_mac, macs['local'])
 
         uplink_mac = network.get_uplink_mac()
         macs['uplink'] = _mac_to_oid(uplink_mac)
-        logging.info('Uplink MAC: %s as OID: %s', uplink_mac,
-                     _mac_to_oid(uplink_mac))
+        logging.info('Uplink MAC: %s as OID: %s', uplink_mac, macs['uplink'])
 
         return self._lookup_ifindex(macs, qbridge=model.qbridge)
 

--- a/site-packages/mlab/disco/discovery.py
+++ b/site-packages/mlab/disco/discovery.py
@@ -103,8 +103,15 @@ class DiscoverySession(object):
         model = self.get_model()
 
         macs = {}
-        macs['local'] = _mac_to_oid(network.get_local_mac())
-        macs['uplink'] = _mac_to_oid(network.get_uplink_mac())
+        local_mac = network.get_local_mac()
+        macs['local'] = _mac_to_oid(local_mac)
+        logging.info('Local MAC: %s as OID: %s', local_mac,
+                     _mac_to_oid(local_mac))
+
+        uplink_mac = network.get_uplink_mac()
+        macs['uplink'] = _mac_to_oid(uplink_mac)
+        logging.info('Uplink MAC: %s as OID: %s', uplink_mac,
+                     _mac_to_oid(uplink_mac))
 
         return self._lookup_ifindex(macs, qbridge=model.qbridge)
 
@@ -158,6 +165,7 @@ class DiscoverySession(object):
         else:
             bridge_oid = _OIDS['BRIDGE-MIB::dot1dTpFdbPort']
 
+        logging.info('snmpwalk %s', bridge_oid)
         bridge_ports = self._session.walk(bridge_oid)
         for port_name, mac_oid in macs.iteritems():
             for bridge_port in bridge_ports:
@@ -167,16 +175,24 @@ class DiscoverySession(object):
 
                 baseport_oid = _OIDS['BRIDGE-MIB::dot1dBasePortIfIndex']
                 try:
+                    logging.info(
+                        'snmpget "BRIDGE-MIB::dot1dBasePortIfIndex.%s"',
+                        bridge_port.value)
                     ifindex = self._session.get(baseport_oid + '.' +
                                                 bridge_port.value)
                 except simple_session.SNMPError:
                     raise PortLookupFailed(
                         'Found MAC OID (%s), but failed to retrieve port' %
                         mac_oid)
-                ifindex_num = ifindex[0].value
 
-                logging.debug('Found: ifIndex for %s is %s', mac_oid,
-                              ifindex_num)
+                ifindex_num = ifindex[0].value
+                if not ifindex_num:
+                    raise PortLookupFailed(
+                        'Received port for MAC OID (%s), but value is empty' %
+                        mac_oid)
+
+                logging.info('Found: ifIndex for %s is %s', mac_oid,
+                             ifindex_num)
                 found_ports.append((port_name, ifindex_num))
                 # We found a matching OID, so continue to next port name.
                 break

--- a/site-packages/mlab/disco/discovery_test.py
+++ b/site-packages/mlab/disco/discovery_test.py
@@ -91,6 +91,27 @@ class DiscoverySessionTest(unittest.TestCase):
 
     @mock.patch.object(network, 'get_local_mac')
     @mock.patch.object(network, 'get_uplink_mac')
+    def test_auto_discover_ifindex_invalid_value_raises_PortLookupFailed(
+            self, mock_get_uplink_mac, mock_get_local_mac):
+        mock_get_uplink_mac.return_value = '00:01:02:03:04:05'
+        mock_get_local_mac.return_value = '00:01:02:03:04:06'
+        # Identify the switch.
+        self.fake_session.prepare('sysDescr.0', 'sysDescr.0',
+                                  _JUNIPER_QFX_SYS_DESCR)
+        # Setup uplink MAC
+        self.fake_session.prepare(
+            discovery._OIDS['Q-BRIDGE-MIB::dot1qTpFdbPort'],
+            discovery._mac_to_oid('00:01:02:03:04:05'), '10')
+        # Return an (invalid) empty ifIndex value.
+        self.fake_session.prepare(
+            discovery._OIDS['BRIDGE-MIB::dot1dBasePortIfIndex'] + '.10',
+            'any_oid_prefix', '')
+
+        with self.assertRaises(discovery.PortLookupFailed):
+            self.session.auto_discover_ifindex()
+
+    @mock.patch.object(network, 'get_local_mac')
+    @mock.patch.object(network, 'get_uplink_mac')
     def test_auto_discover_ifindex_without_qbridge(self, mock_get_uplink_mac,
                                                    mock_get_local_mac):
         mock_get_uplink_mac.return_value = '00:01:02:03:04:05'


### PR DESCRIPTION
This PR adds additional logging messages to assist with debugging auto-discovery in the event of a future issue.

As well, this PR adds a `DEBUG.md` file with notes on manually performing the auto-discovery steps for QFX switches. This can be helpful for identifying where the switch configuration is lacking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/61)
<!-- Reviewable:end -->
