### PR TITLE
Source /etc/profile so HOSTNAME is available

### DIFF
--- a/collectd_mlab.cron
+++ b/collectd_mlab.cron
@@ -7,10 +7,10 @@ SCRIPT=/usr/lib/nagios/plugins/check_collectd_mlab.py
 PROM_FILE=/var/spool/node-exporter/collectd.prom
 PROM_METRIC='collectd_mlab_success{experiment="utility.mlab"}'
 
-# Check the status of collectd-mlab every minute. The script's return code
+# Check the status of collectd-mlab every 5 minutes. The script's return code
 # conforms to Unix-like and Nagios standards where "success" equals 0 and
 # anything else is an error. Prometheus tends to think of "success" as 1 and
 # failure as 0. The following command makes that conversion so that status is
 # more consistent with other Prometheus metrics.
 
-*/5 * * * * root $SCRIPT &> /dev/null; if [[ $? == "0" ]]; then echo "${PROM_METRIC} 1" > $PROM_FILE; else echo "${PROM_METRIC} 0" > $PROM_FILE; fi
+*/5 * * * * root source /etc/profile; $SCRIPT &> /dev/null; if [[ $? == "0" ]]; then echo "${PROM_METRIC} 1" > $PROM_FILE; else echo "${PROM_METRIC} 0" > $PROM_FILE; fi


### PR DESCRIPTION
`check_collectd_mlab.py` depends on the local HOSTNAME environment variable being set. This is automatic for login shells but not for other bash shell, such as from CRON. This change sources /etc/profile to setup HOSTNAME and other common environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/67)
<!-- Reviewable:end -->
