### PR TITLE
Sends output of check_collectd_mlab.py script to a log file in /var/log/

### DIFF
--- a/collectd_mlab.cron
+++ b/collectd_mlab.cron
@@ -4,6 +4,7 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 SCRIPT=/usr/lib/nagios/plugins/check_collectd_mlab.py
+LOG_FILE=/var/log/check_collectd_mlab.log
 PROM_FILE=/var/spool/node-exporter/collectd.prom
 PROM_METRIC='collectd_mlab_success{experiment="utility.mlab"}'
 
@@ -13,4 +14,4 @@ PROM_METRIC='collectd_mlab_success{experiment="utility.mlab"}'
 # failure as 0. The following command makes that conversion so that status is
 # more consistent with other Prometheus metrics.
 
-*/5 * * * * root source /etc/profile; $SCRIPT &> /dev/null; if [[ $? == "0" ]]; then echo "${PROM_METRIC} 1" > $PROM_FILE; else echo "${PROM_METRIC} 0" > $PROM_FILE; fi
+*/5 * * * * root source /etc/profile; $SCRIPT &>> $LOG_FILE; if [[ $? == "0" ]]; then echo "${PROM_METRIC} 1" > $PROM_FILE; else echo "${PROM_METRIC} 0" > $PROM_FILE; fi


### PR DESCRIPTION
For debugging issues with collectd-mlab it may be useful to capture the output of the script that check whether collectd-mlab is healthy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/collectd-mlab/71)
<!-- Reviewable:end -->
